### PR TITLE
ci: use GitHub Actions cache v2 for sccache

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -443,6 +443,7 @@ jobs:
           tags: dcapal-backend:smoke
           build-args: |
             SCCACHE_GHA_VERSION=${{ env.SCCACHE_GHA_VERSION }}
+            SCCACHE_PROBE=${{ github.run_id }}
           secret-envs: |
             actions_runtime_token=ACTIONS_RUNTIME_TOKEN
             actions_results_url=ACTIONS_RESULTS_URL

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -443,7 +443,6 @@ jobs:
           tags: dcapal-backend:smoke
           build-args: |
             SCCACHE_GHA_VERSION=${{ env.SCCACHE_GHA_VERSION }}
-            SCCACHE_PROBE=${{ github.run_id }}
           secret-envs: |
             actions_runtime_token=ACTIONS_RUNTIME_TOKEN
             actions_results_url=ACTIONS_RESULTS_URL

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -12,6 +12,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  ACTIONS_CACHE_SERVICE_V2: "true"
   SCCACHE_BASEDIRS: ${{ github.workspace }}
   SCCACHE_GHA_VERSION: dcapal-v1
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  ACTIONS_CACHE_SERVICE_V2: "true"
   DOCKER_REPO: leonardoarcari/dcapal
   SCCACHE_GHA_VERSION: dcapal-v1
 

--- a/dcapal-backend/docker/Dockerfile.ci
+++ b/dcapal-backend/docker/Dockerfile.ci
@@ -21,6 +21,7 @@ ARG SCCACHE_SHA256=67c4a96dd237c1f518f6b36083f270f9976d516f1e57fce891755ea782e50
 ARG SCCACHE_GHA_VERSION=dcapal-v1
 
 ENV SCCACHE_GHA_ENABLED=true \
+    ACTIONS_CACHE_SERVICE_V2=true \
     SCCACHE_BASEDIRS=/var/dcapal \
     SCCACHE_GHA_VERSION=${SCCACHE_GHA_VERSION} \
     RUSTC_WRAPPER=/usr/local/bin/sccache
@@ -53,7 +54,6 @@ RUN --mount=type=secret,id=actions_runtime_token \
     --mount=type=cache,target=/usr/local/cargo/git/db \
     export ACTIONS_RUNTIME_TOKEN="$(cat /run/secrets/actions_runtime_token)" && \
     export ACTIONS_RESULTS_URL="$(cat /run/secrets/actions_results_url)" && \
-    export SCCACHE_LOG=debug SCCACHE_NO_DAEMON=1 && \
     cargo chef cook --profile release-with-debug --recipe-path recipe.json \
     && sccache --show-stats
 
@@ -68,7 +68,6 @@ RUN --mount=type=secret,id=actions_runtime_token \
     --mount=type=cache,target=/usr/local/cargo/git/db \
     export ACTIONS_RUNTIME_TOKEN="$(cat /run/secrets/actions_runtime_token)" && \
     export ACTIONS_RESULTS_URL="$(cat /run/secrets/actions_results_url)" && \
-    export SCCACHE_LOG=debug SCCACHE_NO_DAEMON=1 && \
     cargo build --profile release-with-debug --bin dcapal-backend --bin migration \
     && mkdir -p /var/dcapal/output \
     && cp /var/dcapal/target/release-with-debug/dcapal-backend /var/dcapal/output/dcapal-backend \

--- a/dcapal-backend/docker/Dockerfile.ci
+++ b/dcapal-backend/docker/Dockerfile.ci
@@ -19,6 +19,7 @@ FROM chef AS builder
 ARG SCCACHE_VERSION=0.17.0
 ARG SCCACHE_SHA256=67c4a96dd237c1f518f6b36083f270f9976d516f1e57fce891755ea782e50006
 ARG SCCACHE_GHA_VERSION=dcapal-v1
+ARG SCCACHE_PROBE=0
 
 ENV SCCACHE_GHA_ENABLED=true \
     ACTIONS_CACHE_SERVICE_V2=true \
@@ -52,10 +53,13 @@ RUN --mount=type=secret,id=actions_runtime_token \
     --mount=type=secret,id=actions_results_url \
     --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git/db \
+    echo "sccache probe ${SCCACHE_PROBE}" >/dev/null && \
     export ACTIONS_RUNTIME_TOKEN="$(cat /run/secrets/actions_runtime_token)" && \
     export ACTIONS_RESULTS_URL="$(cat /run/secrets/actions_results_url)" && \
+    export SCCACHE_LOG=debug SCCACHE_ERROR_LOG=/tmp/sccache.log && \
     cargo chef cook --profile release-with-debug --recipe-path recipe.json \
-    && sccache --show-stats
+    && sccache --show-stats \
+    && { grep -E -i 'write failed|error executing cache write|storage write|status' /tmp/sccache.log | tail -40 || true; }
 
 # Build application
 COPY ./Cargo.toml ./Cargo.toml
@@ -66,13 +70,16 @@ RUN --mount=type=secret,id=actions_runtime_token \
     --mount=type=secret,id=actions_results_url \
     --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git/db \
+    echo "sccache probe ${SCCACHE_PROBE}" >/dev/null && \
     export ACTIONS_RUNTIME_TOKEN="$(cat /run/secrets/actions_runtime_token)" && \
     export ACTIONS_RESULTS_URL="$(cat /run/secrets/actions_results_url)" && \
+    export SCCACHE_LOG=debug SCCACHE_ERROR_LOG=/tmp/sccache.log && \
     cargo build --profile release-with-debug --bin dcapal-backend --bin migration \
     && mkdir -p /var/dcapal/output \
     && cp /var/dcapal/target/release-with-debug/dcapal-backend /var/dcapal/output/dcapal-backend \
     && cp /var/dcapal/target/release-with-debug/migration /var/dcapal/output/migration \
-    && sccache --show-stats
+    && sccache --show-stats \
+    && { grep -E -i 'write failed|error executing cache write|storage write|status' /tmp/sccache.log | tail -40 || true; }
 
 FROM debian:bookworm-slim AS runtime
 # Install runtime dependencies

--- a/dcapal-backend/docker/Dockerfile.ci
+++ b/dcapal-backend/docker/Dockerfile.ci
@@ -53,6 +53,7 @@ RUN --mount=type=secret,id=actions_runtime_token \
     --mount=type=cache,target=/usr/local/cargo/git/db \
     export ACTIONS_RUNTIME_TOKEN="$(cat /run/secrets/actions_runtime_token)" && \
     export ACTIONS_RESULTS_URL="$(cat /run/secrets/actions_results_url)" && \
+    export SCCACHE_LOG=debug SCCACHE_NO_DAEMON=1 && \
     cargo chef cook --profile release-with-debug --recipe-path recipe.json \
     && sccache --show-stats
 
@@ -67,6 +68,7 @@ RUN --mount=type=secret,id=actions_runtime_token \
     --mount=type=cache,target=/usr/local/cargo/git/db \
     export ACTIONS_RUNTIME_TOKEN="$(cat /run/secrets/actions_runtime_token)" && \
     export ACTIONS_RESULTS_URL="$(cat /run/secrets/actions_results_url)" && \
+    export SCCACHE_LOG=debug SCCACHE_NO_DAEMON=1 && \
     cargo build --profile release-with-debug --bin dcapal-backend --bin migration \
     && mkdir -p /var/dcapal/output \
     && cp /var/dcapal/target/release-with-debug/dcapal-backend /var/dcapal/output/dcapal-backend \

--- a/dcapal-backend/docker/Dockerfile.ci
+++ b/dcapal-backend/docker/Dockerfile.ci
@@ -19,7 +19,6 @@ FROM chef AS builder
 ARG SCCACHE_VERSION=0.17.0
 ARG SCCACHE_SHA256=67c4a96dd237c1f518f6b36083f270f9976d516f1e57fce891755ea782e50006
 ARG SCCACHE_GHA_VERSION=dcapal-v1
-ARG SCCACHE_PROBE=0
 
 ENV SCCACHE_GHA_ENABLED=true \
     ACTIONS_CACHE_SERVICE_V2=true \
@@ -53,13 +52,10 @@ RUN --mount=type=secret,id=actions_runtime_token \
     --mount=type=secret,id=actions_results_url \
     --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git/db \
-    echo "sccache probe ${SCCACHE_PROBE}" >/dev/null && \
     export ACTIONS_RUNTIME_TOKEN="$(cat /run/secrets/actions_runtime_token)" && \
     export ACTIONS_RESULTS_URL="$(cat /run/secrets/actions_results_url)" && \
-    export SCCACHE_LOG=debug SCCACHE_ERROR_LOG=/tmp/sccache.log && \
     cargo chef cook --profile release-with-debug --recipe-path recipe.json \
-    && sccache --show-stats \
-    && { grep -E -i 'write failed|error executing cache write|storage write|status' /tmp/sccache.log | tail -40 || true; }
+    && sccache --show-stats
 
 # Build application
 COPY ./Cargo.toml ./Cargo.toml
@@ -70,16 +66,13 @@ RUN --mount=type=secret,id=actions_runtime_token \
     --mount=type=secret,id=actions_results_url \
     --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git/db \
-    echo "sccache probe ${SCCACHE_PROBE}" >/dev/null && \
     export ACTIONS_RUNTIME_TOKEN="$(cat /run/secrets/actions_runtime_token)" && \
     export ACTIONS_RESULTS_URL="$(cat /run/secrets/actions_results_url)" && \
-    export SCCACHE_LOG=debug SCCACHE_ERROR_LOG=/tmp/sccache.log && \
     cargo build --profile release-with-debug --bin dcapal-backend --bin migration \
     && mkdir -p /var/dcapal/output \
     && cp /var/dcapal/target/release-with-debug/dcapal-backend /var/dcapal/output/dcapal-backend \
     && cp /var/dcapal/target/release-with-debug/migration /var/dcapal/output/migration \
-    && sccache --show-stats \
-    && { grep -E -i 'write failed|error executing cache write|storage write|status' /tmp/sccache.log | tail -40 || true; }
+    && sccache --show-stats
 
 FROM debian:bookworm-slim AS runtime
 # Install runtime dependencies


### PR DESCRIPTION
## Summary

Use GitHub Actions cache service v2 for sccache in Docker and runner workflows. The diagnostic run showed v1 requests returning HTTP 404, which sccache treated as read-only.

## Changes

- Set `ACTIONS_CACHE_SERVICE_V2=true` in CI and Publish.
- Set it in the CI Docker image so Cargo Chef and application builds use v2.
- Keep the existing `dcapal-v1` namespace, base-directory normalisation, and GitHub Actions token forwarding.
- Remove the temporary probe after validating sccache itself.

## Validation

- Both workflow files parse with the local YAML parser.
- `git diff --check` passes.
- Targeted smoke build: [run 31695988548](https://github.com/dcapal/dcapal/actions/runs/31695988548/job/94433765083) intentionally invalidated only the Docker compile layers. Cargo Chef reported 720 hits / 201 misses (78.18%), with 0 read and 0 write errors. The application build reported 167 hits / 0 misses (100%), with 0 read and 0 write errors.
- Clean workflow run: [run 31697125487](https://github.com/dcapal/dcapal/actions/runs/31697125487) completed successfully after removing the probe.

## Risk

Pull requests continue to read the published cache; BuildKit layer reuse remains unchanged.