### PR TITLE
feat: switch application database to TimescaleDB 18

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -65,32 +65,15 @@ jobs:
         if: always()
         run: ${SCCACHE_PATH} --show-stats
 
-  backend-test:
-    name: test:backend
+  build-test-backend:
+    name: build:test:backend
     runs-on: ubuntu-latest
     env:
-      SUPABASE_VERSION: 2.110.0
+      POSTGRES_PASSWORD: your-super-secret-and-long-postgres-password
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: sccache
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
-        with:
-          node-version-file: ".nvmrc"
-
-      - name: Cache Supabase CLI npm packages
-        uses: actions/cache@v6
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-supabase-cli-${{ env.SUPABASE_VERSION }}
-          restore-keys: |
-            ${{ runner.os }}-supabase-cli-
-
-      - name: Set up Supabase CLI
-        uses: supabase/setup-cli@v3
-        with:
-          version: ${{ env.SUPABASE_VERSION }}
-
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache: true
@@ -113,6 +96,23 @@ jobs:
       - name: Stop backend database
         if: always()
         run: make backend-db-down
+
+  backend-postgres-upgrade-test:
+    name: test:backend:postgres-upgrade
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: true
+          cache-shared-key: rust-sccache
+          cache-on-failure: false
+          cache-targets: false
+          rustflags: ""
+
+      - name: Verify PostgreSQL 17 to 18 upgrade
+        run: ./dcapal-backend/scripts/verify-postgres-upgrade.sh
 
   backend-openapi-check:
     name: check:openapi:backend
@@ -375,10 +375,11 @@ jobs:
           path: coverage/frontend/
           retention-days: 30
 
-  backend-smoke-test:
-    name: test:smoke:backend
+  test-e2e-smoke:
+    name: test:e2e:smoke
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    needs: optimizer-build-test
     env:
       POSTGRES_HOST: db
       POSTGRES_PORT: 5432
@@ -386,11 +387,40 @@ jobs:
       POSTGRES_PASSWORD: your-super-secret-and-long-postgres-password
       POSTGRES_DB: postgres
       SUPABASE_VERSION: 2.110.0
+      SMOKE_USER_EMAIL: smoke@example.com
+      SMOKE_USER_PASSWORD: smoke-password-123456
+      SMOKE_PORTFOLIO_ID: 11111111-1111-4111-8111-111111111111
+      SMOKE_PORTFOLIO_NAME: Smoke portfolio
     steps:
       - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v7
         with:
           node-version-file: ".nvmrc"
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      # The generated package is a local dependency and must exist before pnpm install.
+      - name: Download dcapal-optimizer-wasm pkg
+        uses: actions/download-artifact@v8
+        with:
+          name: dcapal-optimizer-wasm-pkg
+          path: dcapal-optimizer-wasm/pkg
+
+      - name: Install frontend dependencies
+        run: pnpm install --frozen-lockfile
+
+      # The full-stack smoke uses one Chromium project; the deterministic frontend job owns the browser matrix.
+      - name: Cache Playwright Chromium
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-ms-playwright-v1-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-ms-playwright-v1-
+
+      - name: Install Playwright Chromium
+        run: pnpm --filter @dcapal/frontend exec playwright install --with-deps chromium
 
       # Supabase setup-cli installs the pinned package through npm.
       - name: Cache Supabase CLI npm packages
@@ -460,42 +490,6 @@ jobs:
           POSTGRES_PORT=${POSTGRES_PORT}
           EOF
 
-      - name: Configure dcapal.yml
-        run: |
-          cat > dcapal-backend/dcapal.yml << EOF
-          app:
-            providers:
-              priceProvider: kraken
-              cwApiKey: CW_API_KEY
-              ipApiKey: IP_API_KEY
-            auth:
-              jwtSecret: super-secret-jwt-token-with-at-least-32-characters-long
-
-            log:
-              level: dcapal_backend=info,tower_http=debug
-              file: data/dcapal/dcapal.log
-              enableStdout: true
-
-          server:
-            web:
-              hostname: 0.0.0.0
-              port: 8080
-            metrics:
-              hostname: 0.0.0.0
-              port: 9000
-            redis:
-              hostname: redis
-              port: 6379
-              user: dcapal
-              password: dcapal
-            postgres:
-              hostname: ${POSTGRES_HOST}
-              port: ${POSTGRES_PORT}
-              user: ${POSTGRES_USER}
-              password: ${POSTGRES_PASSWORD}
-              database: ${POSTGRES_DB}
-          EOF
-
       - name: Configure docker compose override
         run: |
           cat > dcapal-backend/docker-compose.override.yml << EOF
@@ -508,6 +502,46 @@ jobs:
       - name: Start Supabase
         run: cd dcapal-backend && supabase start --workdir ./config
 
+      - name: Capture Supabase local environment
+        run: |
+          cd dcapal-backend
+          supabase status --workdir ./config -o env > supabase.env
+          set -a
+          source supabase.env
+          set +a
+          : "${API_URL:?Supabase did not report API_URL}"
+          : "${ANON_KEY:?Supabase did not report ANON_KEY}"
+          : "${SERVICE_ROLE_KEY:?Supabase did not report SERVICE_ROLE_KEY}"
+          : "${JWT_SECRET:?Supabase did not report JWT_SECRET}"
+          JWKS="$(curl --fail --silent --show-error "${API_URL}/auth/v1/.well-known/jwks.json" | jq -c '.')"
+          : "${JWKS:?Supabase did not report signing keys}"
+          {
+            echo "SUPABASE_URL=${API_URL}"
+            echo "SUPABASE_ANON_KEY=${ANON_KEY}"
+            echo "SUPABASE_SERVICE_ROLE_KEY=${SERVICE_ROLE_KEY}"
+            echo "SUPABASE_AUTH_JWT_SECRET=${JWT_SECRET}"
+            echo "SUPABASE_AUTH_JWKS=${JWKS}"
+            echo "VITE_SUPABASE_URL=${API_URL}"
+            echo "VITE_SUPABASE_ANON_KEY=${ANON_KEY}"
+          } >> "$GITHUB_ENV"
+
+      - name: Configure dcapal.yml
+        run: |
+          export DCAPAL_JWT_SECRET="${SUPABASE_AUTH_JWT_SECRET}"
+          export DCAPAL_JWT_JWKS="${SUPABASE_AUTH_JWKS}"
+          export DCAPAL_WEB_HOSTNAME=0.0.0.0
+          export DCAPAL_METRICS_HOSTNAME=0.0.0.0
+          export DCAPAL_REDIS_HOSTNAME=redis
+          export DCAPAL_POSTGRES_HOSTNAME="${POSTGRES_HOST}"
+          export DCAPAL_POSTGRES_PORT="${POSTGRES_PORT}"
+          export DCAPAL_POSTGRES_USER="${POSTGRES_USER}"
+          export DCAPAL_POSTGRES_PASSWORD="${POSTGRES_PASSWORD}"
+          export DCAPAL_POSTGRES_DATABASE="${POSTGRES_DB}"
+          export DCAPAL_LOG_FILE=data/dcapal/dcapal.log
+          export DCAPAL_LOG_ENABLE_STDOUT=true
+          python3 dcapal-backend/scripts/render-dcapal-config.py \
+            --output dcapal-backend/dcapal.yml
+
       - name: Run backend stack and wait for health
         run: |
           cd dcapal-backend
@@ -515,6 +549,19 @@ jobs:
                          -f ./docker/docker-compose.local.yml \
                          -f docker-compose.override.yml \
                          up --no-build --wait --wait-timeout 120
+
+      - name: Run full-stack frontend smoke
+        run: pnpm frontend:test:e2e:smoke
+
+      - name: Assert Timescale smoke data
+        run: dcapal-backend/scripts/assert-smoke-data.sh
+
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: playwright-report-smoke
+          path: dcapal-frontend/playwright-report/
+          retention-days: 30
 
       - name: Print backend logs on failure
         if: ${{ failure() && hashFiles('dcapal-backend/docker-compose.override.yml') != '' }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -212,6 +212,9 @@ jobs:
               image: timescale/timescaledb-ha:pg18.4-ts2.28.3-all-oss
               container_name: ${{ inputs.deploy_environment == 'production' && 'db' || 'db-dev' }}
               restart: always
+              # Let the image entrypoint repair bind-mount ownership before it
+              # drops to the postgres user.
+              user: "0:0"
               # set shared memory limit when using docker-compose
               shm_size: 128mb
               ports:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -209,7 +209,7 @@ jobs:
                 retries: 3
 
             db:
-              image: timescale/timescaledb-ha:pg17
+              image: timescale/timescaledb-ha:pg18.4-ts2.28.3-all-oss
               container_name: ${{ inputs.deploy_environment == 'production' && 'db' || 'db-dev' }}
               restart: always
               # set shared memory limit when using docker-compose
@@ -300,44 +300,25 @@ jobs:
           POSTGRES_PASSWORD: ${{ secrets.PG_DCAPAL_PASSWORD }}
           POSTGRES_DATABASE: ${{ inputs.deploy_environment == 'production' && secrets.POSTGRES_DATABASE || secrets.POSTGRES_DATABASE_DEV }}
         run: |
-          cat > dcapal-backend/dcapal.yml << EOF
-          app:
-            providers:
-              priceProvider: kraken
-              cwApiKey: ${DCAPAL_CW_API_KEY}
-              ipApiKey: ${DCAPAL_IP_API_KEY}
-              cmcApiKey: ${DCAPAL_CMC_API_KEY}
-            auth:
-              jwtSecret: ${JWT_SECRET}
-
-            services:
-              ip:
-                dbPath: data/${IP2LOCATION_FILENAME}
-
-            log:
-              level: dcapal_backend=info,tower_http=debug
-              file: data/dcapal.log
-              enableStdout: false
-
-          server:
-            web:
-              hostname: 0.0.0.0
-              port: 8080
-            metrics:
-              hostname: 0.0.0.0
-              port: 9000
-            redis:
-              hostname: redis
-              port: 6379
-              user: ${REDIS_USER}
-              password: ${REDIS_PASSWORD}
-            postgres:
-              hostname: db
-              port: 5432
-              user: ${POSTGRES_USER}
-              password: ${POSTGRES_PASSWORD}
-              database: ${POSTGRES_DATABASE}
-          EOF
+          export DCAPAL_JWT_SECRET="${JWT_SECRET}"
+          export DCAPAL_CW_API_KEY="${DCAPAL_CW_API_KEY}"
+          export DCAPAL_IP_API_KEY="${DCAPAL_IP_API_KEY}"
+          export DCAPAL_CMC_API_KEY="${DCAPAL_CMC_API_KEY}"
+          export DCAPAL_IP2LOCATION_PATH="data/${IP2LOCATION_FILENAME}"
+          export DCAPAL_WEB_HOSTNAME=0.0.0.0
+          export DCAPAL_METRICS_HOSTNAME=0.0.0.0
+          export DCAPAL_REDIS_HOSTNAME=redis
+          export DCAPAL_REDIS_USER="${REDIS_USER}"
+          export DCAPAL_REDIS_PASSWORD="${REDIS_PASSWORD}"
+          export DCAPAL_POSTGRES_HOSTNAME=db
+          export DCAPAL_POSTGRES_PORT=5432
+          export DCAPAL_POSTGRES_USER="${POSTGRES_USER}"
+          export DCAPAL_POSTGRES_PASSWORD="${POSTGRES_PASSWORD}"
+          export DCAPAL_POSTGRES_DATABASE="${POSTGRES_DATABASE}"
+          export DCAPAL_LOG_FILE=data/dcapal.log
+          export DCAPAL_LOG_ENABLE_STDOUT=false
+          python3 dcapal-backend/scripts/render-dcapal-config.py \
+            --output dcapal-backend/dcapal.yml
 
       - name: Configure dotenv
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -226,8 +226,9 @@ jobs:
               healthcheck:
                 test: [ "CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DATABASE}" ]
                 interval: 10s
-                timeout: 5s
-                retries: 5
+                timeout: 10s
+                retries: 10
+                start_period: 60s
 
           networks:
             ${{ inputs.deploy_environment == 'production' && 'dcapalnetwork' || 'dcapal-dev-network' }}:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -212,9 +212,6 @@ jobs:
               image: timescale/timescaledb-ha:pg18.4-ts2.28.3-all-oss
               container_name: ${{ inputs.deploy_environment == 'production' && 'db' || 'db-dev' }}
               restart: always
-              # Let the image entrypoint repair bind-mount ownership before it
-              # drops to the postgres user.
-              user: "0:0"
               # set shared memory limit when using docker-compose
               shm_size: 128mb
               ports:
@@ -227,7 +224,7 @@ jobs:
               environment:
                 POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
               healthcheck:
-                test: [ "CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DATABASE}" ]
+                test: [ "CMD-SHELL", "pg_isready -U postgres && psql -U postgres -d postgres -c 'SELECT 1' > /dev/null 2>&1" ]
                 interval: 10s
                 timeout: 10s
                 retries: 10
@@ -368,4 +365,4 @@ jobs:
             touch ./data/dcapal/dcapal.log
             docker compose -f docker-compose.yml -f ./docker/docker-compose.prod.yml pull
             docker compose -f docker-compose.yml -f ./docker/docker-compose.prod.yml down
-            docker compose -f docker-compose.yml -f ./docker/docker-compose.prod.yml up -d
+            docker compose -f docker-compose.yml -f ./docker/docker-compose.prod.yml up -d --wait --wait-timeout 180

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,11 @@
 - `docs/` — shared ADRs, research, plans, and agent guidance.
 - `CONTEXT-MAP.md` and each app's `CONTEXT.md` — context boundaries, glossary, and domain relationships.
 
+## Domain docs
 
-## Agent skills
+Multi-context layout: root `CONTEXT-MAP.md` with per-app `CONTEXT.md` files and ADRs. See `docs/agents/domain.md`.
+
+## Project management
 
 ### Issue tracker
 
@@ -18,6 +21,16 @@ Issues and PRDs for this repo live as GitHub issues; use the `gh` CLI. See `docs
 
 Use the default labels: `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, and `wontfix`. See `docs/agents/triage-labels.md`.
 
-### Domain docs
+## Code authoring
 
-Multi-context layout: root `CONTEXT-MAP.md` with per-app `CONTEXT.md` files and ADRs. See `docs/agents/domain.md`.
+The following rules apply to all code in this repo. Nested `AGENTS.md` files extend the following with app-specific rules.
+
+### Comments
+
+- Always document public types, functions, constants. Document private helpers and code blocks when longer than 10 lines and in general when the intent is not immediately obvious.
+- Comments must state the "What", not the "How". The "How" is stated in code. The "What" informs an unfamiliar reader about the intent of a piece of code, so they don't have to dive into the implementation details.
+
+### Tests
+
+- Prefer integration tests over unit tests except for pure business logic and calculations. Integration test interfaces are more stable and need less maintenance.
+- Tests should always have documentation explaining the scenario in plain English and the expecations. Ideally, a reader shouldn't need to dive into the implementation to understand the scenario covered. They should follow the GIVEN, WHEN, THEN format.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,7 +883,6 @@ dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
  "migration",
- "once_cell",
  "parking_lot",
  "redis",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,6 @@ log = "0.4.33"
 metrics = "0.24.6"
 metrics-exporter-prometheus = "0.18.3"
 minilp = "0.2.2"
-once_cell = "1.21.4"
 parking_lot = "0.12.5"
 rand = "0.10.2"
 redis = { version = "1.5.0", features = ["tokio-comp"] }

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ supabase-down:  ## Stop Supabase
 
 ## Start the TimescaleDB database used by backend development and tests
 backend-db-up:  ## Start the backend database
-	cd $(DCAPAL_BACKEND_DIR) && env POSTGRES_PASSWORD="$(POSTGRES_PASSWORD)" docker compose $(COMPOSE_BASE_ARGS) up -d --wait --wait-timeout 120 db
+	cd $(DCAPAL_BACKEND_DIR) && env POSTGRES_PASSWORD="$(POSTGRES_PASSWORD)" docker compose $(COMPOSE_BASE_ARGS) up -d --wait --wait-timeout 180 db
 
 ## Stop the TimescaleDB database used by backend development and tests
 backend-db-down:  ## Stop the backend database

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,15 @@
+SHELL := /bin/bash
+
 COMPOSE_BASE_ARGS := -f docker-compose.yml -f docker/docker-compose.dev.yml
 DCAPAL_BACKEND_DIR := ./dcapal-backend
 DCAPAL_OPTIMIZER_DIR := ./dcapal-optimizer-wasm/crates/optimizer
 DCAPAL_FRONTEND_DIR := ./dcapal-frontend
 SUPABASE_WORKDIR := ./config
-SUPABASE_DATABASE_URL ?= postgresql://postgres:postgres@127.0.0.1:54322/postgres
-DATABASE_URL ?= $(SUPABASE_DATABASE_URL)
+POSTGRES_PASSWORD ?= postgres
+TIMESCALE_DATABASE_URL ?= postgresql://postgres:$(POSTGRES_PASSWORD)@127.0.0.1:5433/postgres
+DATABASE_URL ?= $(TIMESCALE_DATABASE_URL)
 
-.PHONY: help supabase-up supabase-down backend-db-up backend-db-down backend-db-check backend-migrate test-backend docker-dev-up docker-dev-down dev-up dev-down export-openapi
+.PHONY: help supabase-up supabase-down render-local-config local-up local-down backend-db-up backend-db-down backend-db-check backend-migrate test-backend docker-dev-up docker-dev-down dev-up dev-down export-openapi
 
 ## Show this help message
 help:
@@ -78,11 +81,14 @@ supabase-up:  ## Start Supabase with config
 supabase-down:  ## Stop Supabase
 	cd $(DCAPAL_BACKEND_DIR) && npx supabase stop --workdir $(SUPABASE_WORKDIR)
 
-## Start the Supabase database used by backend development and tests
-backend-db-up: supabase-up  ## Start the backend database
+## Start the TimescaleDB database used by backend development and tests
+backend-db-up:  ## Start the backend database
+	cd $(DCAPAL_BACKEND_DIR) && env POSTGRES_PASSWORD="$(POSTGRES_PASSWORD)" docker compose $(COMPOSE_BASE_ARGS) up -d --wait --wait-timeout 120 db
 
-## Stop the Supabase database used by backend development and tests
-backend-db-down: supabase-down  ## Stop the backend database
+## Stop the TimescaleDB database used by backend development and tests
+backend-db-down:  ## Stop the backend database
+	cd $(DCAPAL_BACKEND_DIR) && docker compose $(COMPOSE_BASE_ARGS) stop db
+	cd $(DCAPAL_BACKEND_DIR) && docker compose $(COMPOSE_BASE_ARGS) rm --force db
 
 ## Check that the backend database is already running
 backend-db-check:  ## Check backend database connectivity
@@ -123,7 +129,15 @@ dev-up: supabase-up docker-dev-up  ## Start full dev environment (Supabase + Doc
 dev-down: docker-dev-down supabase-down  ## Stop full dev environment
 ## Start full dev+local environment (Supabase + Docker)
 
-local-up: supabase-up docker-local-up  ## Start full dev environment (Supabase + Docker)
+render-local-config: supabase-up  ## Render the local backend config from Supabase's signing keys
+	cd $(DCAPAL_BACKEND_DIR) && \
+		eval "$$(npx supabase status --workdir ./config -o env)" && \
+		DCAPAL_JWT_SECRET="$$JWT_SECRET" \
+		DCAPAL_JWT_JWKS="$$(curl --fail --silent --show-error "$$API_URL/auth/v1/.well-known/jwks.json")" \
+		python3 scripts/render-dcapal-config.py --output dcapal.yml
+
+local-up: render-local-config  ## Start full dev environment (Supabase + Docker)
+	$(MAKE) docker-local-up
 
 ## Stop full dev+local environment
 local-down: docker-local-down supabase-down  ## Stop full dev environment

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,15 @@ supabase-down:  ## Stop Supabase
 
 ## Start the TimescaleDB database used by backend development and tests
 backend-db-up:  ## Start the backend database
-	cd $(DCAPAL_BACKEND_DIR) && env POSTGRES_PASSWORD="$(POSTGRES_PASSWORD)" docker compose $(COMPOSE_BASE_ARGS) up -d --wait --wait-timeout 180 db
+	cd $(DCAPAL_BACKEND_DIR) && env POSTGRES_PASSWORD="$(POSTGRES_PASSWORD)" docker compose $(COMPOSE_BASE_ARGS) up -d db
+	cd $(DCAPAL_BACKEND_DIR) && for attempt in $$(seq 1 180); do \
+		if docker compose $(COMPOSE_BASE_ARGS) exec -T db psql -U postgres -d postgres -c 'SELECT 1' >/dev/null 2>&1; then \
+			exit 0; \
+		fi; \
+		sleep 1; \
+	done; \
+	docker compose $(COMPOSE_BASE_ARGS) logs db; \
+	exit 1
 
 ## Stop the TimescaleDB database used by backend development and tests
 backend-db-down:  ## Stop the backend database

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 SHELL := /bin/bash
 
-COMPOSE_BASE_ARGS := -f docker-compose.yml -f docker/docker-compose.dev.yml
+COMPOSE_DEV_ARGS := -f docker-compose.yml -f docker/docker-compose.dev.yml
+COMPOSE_TEST_ARGS := -f docker-compose.yml -f docker/docker-compose.test.yml
 DCAPAL_BACKEND_DIR := ./dcapal-backend
 DCAPAL_OPTIMIZER_DIR := ./dcapal-optimizer-wasm/crates/optimizer
 DCAPAL_FRONTEND_DIR := ./dcapal-frontend
@@ -83,20 +84,12 @@ supabase-down:  ## Stop Supabase
 
 ## Start the TimescaleDB database used by backend development and tests
 backend-db-up:  ## Start the backend database
-	cd $(DCAPAL_BACKEND_DIR) && env POSTGRES_PASSWORD="$(POSTGRES_PASSWORD)" docker compose $(COMPOSE_BASE_ARGS) up -d db
-	cd $(DCAPAL_BACKEND_DIR) && for attempt in $$(seq 1 180); do \
-		if docker compose $(COMPOSE_BASE_ARGS) exec -T db psql -U postgres -d postgres -c 'SELECT 1' >/dev/null 2>&1; then \
-			exit 0; \
-		fi; \
-		sleep 1; \
-	done; \
-	docker compose $(COMPOSE_BASE_ARGS) logs db; \
-	exit 1
+	cd $(DCAPAL_BACKEND_DIR) && env POSTGRES_PASSWORD="$(POSTGRES_PASSWORD)" docker compose $(COMPOSE_TEST_ARGS) up -d --wait --wait-timeout 180 db
 
 ## Stop the TimescaleDB database used by backend development and tests
 backend-db-down:  ## Stop the backend database
-	cd $(DCAPAL_BACKEND_DIR) && docker compose $(COMPOSE_BASE_ARGS) stop db
-	cd $(DCAPAL_BACKEND_DIR) && docker compose $(COMPOSE_BASE_ARGS) rm --force db
+	cd $(DCAPAL_BACKEND_DIR) && docker compose $(COMPOSE_TEST_ARGS) stop db
+	cd $(DCAPAL_BACKEND_DIR) && docker compose $(COMPOSE_TEST_ARGS) rm --force db
 
 ## Check that the backend database is already running
 backend-db-check:  ## Check backend database connectivity
@@ -112,23 +105,23 @@ test-backend: backend-db-check  ## Run backend tests (requires backend-db-up)
 
 ## Start development Docker containers
 docker-dev-up:  ## Start development Docker containers
-	cd $(DCAPAL_BACKEND_DIR) && docker compose $(COMPOSE_BASE_ARGS) up -d
+	cd $(DCAPAL_BACKEND_DIR) && docker compose $(COMPOSE_DEV_ARGS) up -d
 
 ## Stop development Docker containers
 docker-dev-down:  ## Stop development Docker containers
-	cd $(DCAPAL_BACKEND_DIR) && docker compose $(COMPOSE_BASE_ARGS) down
+	cd $(DCAPAL_BACKEND_DIR) && docker compose $(COMPOSE_DEV_ARGS) down
 
 ## Start development Docker containers with Dcapal image
 docker-local-build:  ## Start development Docker containers
-	cd $(DCAPAL_BACKEND_DIR) && docker compose $(COMPOSE_BASE_ARGS) -f docker/docker-compose.local.yml build
+	cd $(DCAPAL_BACKEND_DIR) && docker compose $(COMPOSE_DEV_ARGS) -f docker/docker-compose.local.yml build
 
 ## Start development Docker containers with Dcapal image
 docker-local-up:  ## Start development Docker containers
-	cd $(DCAPAL_BACKEND_DIR) && docker compose $(COMPOSE_BASE_ARGS) -f docker/docker-compose.local.yml up -d
+	cd $(DCAPAL_BACKEND_DIR) && docker compose $(COMPOSE_DEV_ARGS) -f docker/docker-compose.local.yml up -d
 
 ## Start development Docker containers with Dcapal image
 docker-local-down:  ## Stop development Docker containers
-	cd $(DCAPAL_BACKEND_DIR) && docker compose $(COMPOSE_BASE_ARGS) -f docker/docker-compose.local.yml down
+	cd $(DCAPAL_BACKEND_DIR) && docker compose $(COMPOSE_DEV_ARGS) -f docker/docker-compose.local.yml down
 
 ## Start full dev environment (Supabase + Docker)
 dev-up: supabase-up docker-dev-up  ## Start full dev environment (Supabase + Docker)

--- a/README.md
+++ b/README.md
@@ -38,45 +38,19 @@ You can start using [DcaPal](https://dcapal.com) right away. It's free. No regis
 DcaPal does not store any user data. But if you are still concerned for your privacy, you can build and run it on your
 machine.
 
-**Start Docker environment**
+**Start the local application environment**
 
-- Setup the `.env` file
-
-```bash
-cp dcapal-backend/.env.example dcapal-backend/.env
-```
-
-- Setup a password for the db and the JWT secret (you can use `openssl rand -base64 32` to generate a random string) in
-  the new `.env` file
-
-```dotenv
-POSTGRES_PASSWORD=<replace-with-your-pwd>
-JWT_SECRET=<generated_secret>
-```
-
-- Start the Docker environment
+`make local-up` starts the local Supabase Auth stack, renders the ignored
+backend configuration with its JWT signing keys, and starts the TimescaleDB,
+Redis, and DcaPal containers. Supabase's PostgreSQL instance is not used for
+DcaPal migrations or application data.
 
 ```bash
-make dev-up
+make local-up
 ```
 
 (Note: if you're using a Mac with an ARM processor, you should replace (in the docker-compose dev file) Cadvisor's image
 version with gcr.io/cadvisor/cadvisor:v0.47.1 and set platform: linux/aarch64)
-
-**Run DcaPal backend**
-
-Prepare `dcapal.yml` config file
-
-```bash
-cd dcapal-backend
-cp config/dcapal/dcapal.yml dcapal.yml
-```
-
-Compile and start backend service
-
-```bash
-cargo run --bin dcapal-backend --release
-```
 
 **Run DcaPal frontend**
 

--- a/dcapal-backend/CONTEXT.md
+++ b/dcapal-backend/CONTEXT.md
@@ -2,6 +2,19 @@
 
 DcaPal Backend provides market data, temporary portfolio transfer, and remote storage for authenticated users' saved portfolios. It does not execute trades or calculate allocation recommendations.
 
+## Remote storage language
+
+**Application data store**:
+The durable PostgreSQL-backed store for DcaPal users, saved portfolios, and
+portfolio assets. It is separate from the service that authenticates users.
+_Avoid_: Authentication database; Supabase database
+
+**Authentication service**:
+The separate Supabase service that issues and validates user sessions. Its
+internal data store holds authentication-service data, not DcaPal saved
+portfolios, and does not receive DcaPal schema migrations.
+_Avoid_: Application data store; application database
+
 ## Market data language
 
 **Market asset**:

--- a/dcapal-backend/README.md
+++ b/dcapal-backend/README.md
@@ -1,8 +1,9 @@
 # DcaPal backend service
 
-The backend uses PostgreSQL through SQLx. Local PostgreSQL is provided by the
-Supabase CLI, and the migration runner keeps the existing production tables in
-place while creating SQLx migration history in `_sqlx_migrations`.
+The backend uses TimescaleDB PostgreSQL through SQLx. The Compose `db` service
+is the application database for local development, migrations, and backend
+tests. Supabase is a separate authentication stack used by the full-stack
+smoke test; its own PostgreSQL database does not receive DcaPal migrations.
 
 ## Run backend tests
 
@@ -15,8 +16,9 @@ make test-backend
 make backend-db-down
 ```
 
-`make test-backend` checks the configured `DATABASE_URL` and fails if the
-database is not already running. To apply pending migrations manually, run:
+`make test-backend` checks the configured TimescaleDB `DATABASE_URL` and fails
+if the database is not already running. To apply pending migrations manually,
+run:
 
 ```bash
 make backend-migrate
@@ -24,42 +26,25 @@ make backend-migrate
 
 ## How-to
 
-### Run as Docker container locally
+### Run as a Docker container locally
 
-- Build backend image
+`make local-up` renders the ignored `dcapal.yml` from the checked-in template,
+using the local Supabase signing keys, and starts the application stack. Do
+not copy the template directly: it contains renderer placeholders.
+
+Build the backend image:
 
 ```bash
 make docker-local-build
 ```
 
-- Update `dcapal.yml` config
-
-```yml
-app:
-# App configs
-
-server:
-redis:
-  hostname: redis # IMPORTANT!
-  port: 6379
-  user: dcapal
-  password: dcapal
-postgres:
-  hostname: postgres # IMPORTANT!
-  port: 5432 # IMPORTANT!
-  user: postgres
-  password: postgres
-  database: postgres
-
-```
-
-- Start the container stack
+Start the container stack:
 
 ```bash
 make local-up
 ```
 
-- Stop the container stack
+Stop the container stack:
 
 ```bash
 make local-down

--- a/dcapal-backend/config/dcapal/dcapal.yml
+++ b/dcapal-backend/config/dcapal/dcapal.yml
@@ -1,36 +1,35 @@
 app:
   providers:
-    priceProvider: kraken
-    cwApiKey: CW_API_KEY
-    ipApiKey: IP_API_KEY
-    # cmcApiKey: CMC_API_KEY
+    priceProvider: @@DCAPAL_PRICE_PROVIDER@@
+    cwApiKey: @@DCAPAL_CW_API_KEY@@
+    ipApiKey: @@DCAPAL_IP_API_KEY@@
+    cmcApiKey: @@DCAPAL_CMC_API_KEY@@
   auth:
-    jwtSecret: SUPABASE_JWT_SECRET
+    jwtSecret: @@DCAPAL_JWT_SECRET@@
+    jwtJwks: @@DCAPAL_JWT_JWKS@@
 
-  # services:
-  #   ip:
-  #     dbPath: PATH_TO_IP2LOCATION_BIN
+  services: @@DCAPAL_SERVICES@@
 
   log:
-    level: dcapal_backend=info,tower_http=debug
-    file: dcapal.log
-    enableStdout: true
+    level: @@DCAPAL_LOG_LEVEL@@
+    file: @@DCAPAL_LOG_FILE@@
+    enableStdout: @@DCAPAL_LOG_ENABLE_STDOUT@@
 
 server:
   web:
-    hostname: 127.0.0.1
-    port: 8080
+    hostname: @@DCAPAL_WEB_HOSTNAME@@
+    port: @@DCAPAL_WEB_PORT@@
   metrics:
-    hostname: 127.0.0.1
-    port: 9000
+    hostname: @@DCAPAL_METRICS_HOSTNAME@@
+    port: @@DCAPAL_METRICS_PORT@@
   redis:
-    hostname: 127.0.0.1
-    port: 6379
-    user: dcapal
-    password: dcapal
+    hostname: @@DCAPAL_REDIS_HOSTNAME@@
+    port: @@DCAPAL_REDIS_PORT@@
+    user: @@DCAPAL_REDIS_USER@@
+    password: @@DCAPAL_REDIS_PASSWORD@@
   postgres:
-    hostname: 127.0.0.1
-    port: 54322
-    user: postgres
-    password: postgres
-    database: postgres
+    hostname: @@DCAPAL_POSTGRES_HOSTNAME@@
+    port: @@DCAPAL_POSTGRES_PORT@@
+    user: @@DCAPAL_POSTGRES_USER@@
+    password: @@DCAPAL_POSTGRES_PASSWORD@@
+    database: @@DCAPAL_POSTGRES_DATABASE@@

--- a/dcapal-backend/crates/backend/Cargo.toml
+++ b/dcapal-backend/crates/backend/Cargo.toml
@@ -26,7 +26,6 @@ jsonwebtoken = { workspace = true }
 lazy_static = { workspace = true }
 metrics = { workspace = true }
 metrics-exporter-prometheus = { workspace = true }
-once_cell = { workspace = true }
 parking_lot = { workspace = true }
 redis = { workspace = true }
 reqwest = { workspace = true }

--- a/dcapal-backend/crates/backend/src/app/infra/claim.rs
+++ b/dcapal-backend/crates/backend/src/app/infra/claim.rs
@@ -46,6 +46,12 @@ pub struct UserMetadataClaim {
 }
 
 impl Claims {
+    /// Decodes a Supabase JWT using the configured authentication keys.
+    ///
+    /// HS256 tokens use the shared JWT secret. ES256 tokens require a key ID
+    /// that matches a compatible JWK in the configured public key set.
+    /// Unsupported algorithms, missing keys, mismatched key IDs, and malformed
+    /// keys are rejected.
     pub fn decode(
         token: &str,
         jwt_secret: &str,
@@ -92,6 +98,9 @@ impl FromRequestParts<AppContext> for Claims {
 
 #[cfg(test)]
 mod tests {
+    //! These tests cover shared-secret HS256 tokens, matching ES256 JWKs, and
+    //! rejection of missing, mismatched, malformed, or unsupported keys.
+
     use jsonwebtoken::{
         EncodingKey, Header, encode,
         jwk::{Jwk, JwkSet, PublicKeyUse},

--- a/dcapal-backend/crates/backend/src/app/infra/claim.rs
+++ b/dcapal-backend/crates/backend/src/app/infra/claim.rs
@@ -3,19 +3,23 @@ use axum_extra::{
     TypedHeader,
     headers::{Authorization, authorization::Bearer},
 };
-use jsonwebtoken::{Algorithm, DecodingKey, TokenData, Validation};
-use once_cell::sync::Lazy;
+use jsonwebtoken::{
+    Algorithm, DecodingKey, TokenData, Validation, decode_header,
+    errors::ErrorKind,
+    jwk::{JwkSet, KeyAlgorithm},
+};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::{AppContext, error::DcaError};
 
 const JWT_AUDIENCE_DOMAIN: &str = "authenticated";
-pub static DECODE_HEADER: Lazy<Validation> = Lazy::new(|| {
-    let mut validation = Validation::new(Algorithm::HS256);
+
+fn validation_for(algorithm: Algorithm) -> Validation {
+    let mut validation = Validation::new(algorithm);
     validation.set_audience(&[JWT_AUDIENCE_DOMAIN.to_string()]);
     validation
-});
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Claims {
@@ -44,9 +48,24 @@ pub struct UserMetadataClaim {
 impl Claims {
     pub fn decode(
         token: &str,
-        key: &DecodingKey,
+        jwt_secret: &str,
+        jwks: &JwkSet,
     ) -> Result<TokenData<Self>, jsonwebtoken::errors::Error> {
-        jsonwebtoken::decode::<Claims>(token, key, &DECODE_HEADER)
+        let header = decode_header(token)?;
+        let key = match header.alg {
+            Algorithm::HS256 => DecodingKey::from_secret(jwt_secret.as_ref()),
+            Algorithm::ES256 => {
+                let kid = header.kid.ok_or(ErrorKind::InvalidToken)?;
+                let jwk = jwks.find(&kid).ok_or(ErrorKind::InvalidToken)?;
+                if jwk.common.key_algorithm != Some(KeyAlgorithm::ES256) {
+                    return Err(ErrorKind::InvalidAlgorithm.into());
+                }
+                DecodingKey::from_jwk(jwk)?
+            }
+            _ => return Err(ErrorKind::InvalidAlgorithm.into()),
+        };
+
+        jsonwebtoken::decode::<Self>(token, &key, &validation_for(header.alg))
     }
 }
 
@@ -60,12 +79,8 @@ impl FromRequestParts<AppContext> for Claims {
         let TypedHeader(Authorization(bearer)) = parts
             .extract::<TypedHeader<Authorization<Bearer>>>()
             .await?;
-        let jwt_secret = state.config.app.auth.jwt_secret.clone();
-        let user_claims = Claims::decode(
-            bearer.token(),
-            &DecodingKey::from_secret(jwt_secret.as_ref()),
-        )?
-        .claims;
+        let auth = &state.config.app.auth;
+        let user_claims = Claims::decode(bearer.token(), &auth.jwt_secret, &auth.jwt_jwks)?.claims;
         let _ = state
             .repos
             .user
@@ -73,4 +88,126 @@ impl FromRequestParts<AppContext> for Claims {
             .await?;
         Ok(user_claims)
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use jsonwebtoken::{
+        EncodingKey, Header, encode,
+        jwk::{Jwk, JwkSet, PublicKeyUse},
+    };
+
+    use super::*;
+
+    fn sample_claims() -> Claims {
+        Claims {
+            iat: 1_700_000_000,
+            exp: 4_000_000_000,
+            sub: Uuid::from_u128(1),
+            session_id: Uuid::from_u128(2),
+            role: "authenticated".to_string(),
+            aud: JWT_AUDIENCE_DOMAIN.to_string(),
+            user_metadata: UserMetadataClaim {
+                email: "smoke@example.com".to_string(),
+                full_name: Some("Smoke User".to_string()),
+            },
+        }
+    }
+
+    #[test]
+    fn decodes_hs256_with_the_shared_secret() {
+        let claims = sample_claims();
+        let token = encode(
+            &Header::new(Algorithm::HS256),
+            &claims,
+            &EncodingKey::from_secret(b"test-secret"),
+        )
+        .unwrap();
+
+        let decoded = Claims::decode(&token, "test-secret", &JwkSet { keys: Vec::new() }).unwrap();
+
+        assert_eq!(decoded.claims.user_metadata.email, "smoke@example.com");
+    }
+
+    #[test]
+    fn decodes_es256_with_the_matching_jwk() {
+        let claims = sample_claims();
+        let token = signed_es256_token(Some("test-key"), &claims);
+        let decoded = Claims::decode(&token, "unused-secret", &test_jwks("test-key")).unwrap();
+
+        assert_eq!(decoded.claims.sub, claims.sub);
+    }
+
+    #[test]
+    fn rejects_es256_without_a_matching_key_id() {
+        let token = signed_es256_token(Some("test-key"), &sample_claims());
+
+        assert!(Claims::decode(&token, "unused-secret", &test_jwks("different-key"),).is_err());
+    }
+
+    #[test]
+    fn rejects_es256_without_a_key_id() {
+        let token = signed_es256_token(None, &sample_claims());
+
+        assert!(Claims::decode(&token, "unused-secret", &test_jwks("test-key"),).is_err());
+    }
+
+    #[test]
+    fn rejects_a_malformed_jwk() {
+        let token = signed_es256_token(Some("test-key"), &sample_claims());
+        let malformed_jwks = serde_json::from_value(serde_json::json!({
+            "keys": [{
+                "alg": "ES256",
+                "crv": "P-256",
+                "kid": "test-key",
+                "kty": "EC",
+                "x": "!",
+                "y": "wQg1EytcsEmGrM70Gb53oluoDbVhCZ3Uq3hHMslHVb4"
+            }]
+        }))
+        .unwrap();
+
+        assert!(Claims::decode(&token, "unused-secret", &malformed_jwks).is_err());
+    }
+
+    #[test]
+    fn rejects_an_unsupported_algorithm() {
+        let token = encode(
+            &Header::new(Algorithm::HS384),
+            &sample_claims(),
+            &EncodingKey::from_secret(b"test-secret"),
+        )
+        .unwrap();
+
+        let error = Claims::decode(&token, "test-secret", &JwkSet { keys: Vec::new() })
+            .expect_err("HS384 must not be accepted");
+
+        assert!(matches!(error.kind(), ErrorKind::InvalidAlgorithm));
+    }
+
+    fn signed_es256_token(kid: Option<&str>, claims: &Claims) -> String {
+        let mut header = Header::new(Algorithm::ES256);
+        header.kid = kid.map(str::to_owned);
+
+        encode(
+            &header,
+            claims,
+            &EncodingKey::from_ec_pem(EC_PRIVATE_KEY.as_bytes()).unwrap(),
+        )
+        .unwrap()
+    }
+
+    fn test_jwks(kid: &str) -> JwkSet {
+        let encoding_key = EncodingKey::from_ec_pem(EC_PRIVATE_KEY.as_bytes()).unwrap();
+        let mut jwk = Jwk::from_encoding_key(&encoding_key, Algorithm::ES256).unwrap();
+        jwk.common.key_id = Some(kid.to_string());
+        jwk.common.public_key_use = Some(PublicKeyUse::Signature);
+        JwkSet { keys: vec![jwk] }
+    }
+
+    const EC_PRIVATE_KEY: &str = "-----BEGIN PRIVATE KEY-----\n\
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgWTFfCGljY6aw3Hrt\n\
+kHmPRiazukxPLb6ilpRAewjW8nihRANCAATDskChT+Altkm9X7MI69T3IUmrQU0L\n\
+950IxEzvw/x5BMEINRMrXLBJhqzO9Bm+d6JbqA21YQmd1Kt4RzLJR1W+\n\
+-----END PRIVATE KEY-----\n";
 }

--- a/dcapal-backend/crates/backend/src/config.rs
+++ b/dcapal-backend/crates/backend/src/config.rs
@@ -42,10 +42,15 @@ pub struct Providers {
 #[serde(rename_all = "camelCase")]
 pub struct Auth {
     pub jwt_secret: String,
+    /// Optional Supabase public keys used to validate ES256 access tokens.
+    ///
+    /// HS256 validation continues to use `jwt_secret`. An empty key set keeps
+    /// configurations that only use the shared-secret validation path valid.
     #[serde(default = "default_jwt_jwks")]
     pub jwt_jwks: JwkSet,
 }
 
+/// Supplies an empty public-key set when older configuration omits JWKS.
 fn default_jwt_jwks() -> JwkSet {
     JwkSet { keys: Vec::new() }
 }

--- a/dcapal-backend/crates/backend/src/config.rs
+++ b/dcapal-backend/crates/backend/src/config.rs
@@ -1,3 +1,4 @@
+use jsonwebtoken::jwk::JwkSet;
 use serde::{Deserialize, Serialize};
 
 use crate::error::Result;
@@ -41,6 +42,12 @@ pub struct Providers {
 #[serde(rename_all = "camelCase")]
 pub struct Auth {
     pub jwt_secret: String,
+    #[serde(default = "default_jwt_jwks")]
+    pub jwt_jwks: JwkSet,
+}
+
+fn default_jwt_jwks() -> JwkSet {
+    JwkSet { keys: Vec::new() }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/dcapal-backend/crates/migration/README.md
+++ b/dcapal-backend/crates/migration/README.md
@@ -4,7 +4,7 @@ The migration crate embeds the SQL files in `dcapal-backend/migrations` and
 runs them against the URL in `DATABASE_URL`:
 
 ```sh
-DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres \
+DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5433/postgres \
   cargo run -p migration
 ```
 

--- a/dcapal-backend/docker-compose.yml
+++ b/dcapal-backend/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       retries: 3
 
   db:
-    image: timescale/timescaledb-ha:pg17
+    image: timescale/timescaledb-ha:pg18.4-ts2.28.3-all-oss
     container_name: db
     restart: always
     expose:

--- a/dcapal-backend/docker-compose.yml
+++ b/dcapal-backend/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       interval: 10s
       timeout: 10s
       retries: 10
-      start_period: 30s
+      start_period: 60s
 
 networks:
   dcapalnetwork:

--- a/dcapal-backend/docker/docker-compose.dev.yml
+++ b/dcapal-backend/docker/docker-compose.dev.yml
@@ -6,9 +6,6 @@ services:
       - 8001:8001
 
   db:
-    # The image entrypoint uses root to repair bind-mount ownership, then
-    # drops to the postgres user before starting the server.
-    user: "0:0"
     ports:
       - "5433:5432"
     volumes:

--- a/dcapal-backend/docker/docker-compose.dev.yml
+++ b/dcapal-backend/docker/docker-compose.dev.yml
@@ -6,6 +6,9 @@ services:
       - 8001:8001
 
   db:
+    # The image entrypoint uses root to repair bind-mount ownership, then
+    # drops to the postgres user before starting the server.
+    user: "0:0"
     ports:
       - "5433:5432"
     volumes:

--- a/dcapal-backend/docker/docker-compose.test.yml
+++ b/dcapal-backend/docker/docker-compose.test.yml
@@ -1,0 +1,4 @@
+services:
+  db:
+    ports:
+      - "5433:5432"

--- a/dcapal-backend/docs/adr/0001-sqlx-persistence-and-migrations.md
+++ b/dcapal-backend/docs/adr/0001-sqlx-persistence-and-migrations.md
@@ -28,7 +28,7 @@ fixtures for repository integration tests.
 
 The backend no longer depends on SeaORM or its migration CLI. Deployments keep
 their current startup order and command form, while local tests require a
-running Supabase PostgreSQL instance. SQLx migrations have a separate history,
-so old SeaORM migration metadata remains visible for compatibility. Portfolio
-asset uniqueness is intentionally not added here; it is tracked separately in
-[issue #714](https://github.com/dcapal/dcapal/issues/714).
+running application PostgreSQL instance. SQLx migrations have a separate
+history, so old SeaORM migration metadata remains visible for compatibility.
+Portfolio asset uniqueness is intentionally not added here; it is tracked
+separately in [issue #714](https://github.com/dcapal/dcapal/issues/714).

--- a/dcapal-backend/docs/adr/0002-timescaledb-application-database.md
+++ b/dcapal-backend/docs/adr/0002-timescaledb-application-database.md
@@ -1,0 +1,55 @@
+# ADR 0002: Use TimescaleDB PostgreSQL as the application database
+
+- Status: accepted
+- Date: 2026-08-13
+
+## Context
+
+DcaPal uses SQLx migrations and PostgreSQL repositories for users, saved
+portfolios, and portfolio assets. The repository also runs Supabase for
+authentication. These are two different database boundaries: Supabase's
+internal PostgreSQL instance supports the authentication stack, while DcaPal's
+Compose `db` service stores application data.
+
+Using different database implementations for local development, backend tests,
+and the application runtime would allow SQL that works in one environment to
+fail in another. The application database therefore needs one explicit
+TimescaleDB PostgreSQL 18 contract.
+
+## Decision
+
+Use the official image tag
+`timescale/timescaledb-ha:pg18.4-ts2.28.3-all-oss` for the Compose-managed
+DcaPal application database. The tag is intentionally used without a digest;
+the image tag is the repository's version contract.
+
+Run SQLx migrations and ordinary backend tests against this TimescaleDB
+service. Keep Supabase separate and start it only for workflows that exercise
+Supabase-specific authentication, including the full-stack browser smoke test.
+
+The backend keeps the configured shared JWT secret for HS256 tokens and also
+accepts the public ES256 signing keys exposed by current local Supabase Auth
+through the optional `jwtJwks` setting. The smoke setup supplies those public
+keys; no private key or production secret is committed.
+
+TimescaleDB extension availability is owned by database provisioning. The
+backend does not add a startup capability check, a warning query, or a runtime
+fallback to plain PostgreSQL. This issue also does not introduce hypertables,
+UUIDv7 identifiers, or new application tables.
+
+## Consequences
+
+The local `make backend-db-up` target starts TimescaleDB on port 5433, and
+`make test-backend` uses that database by default. The ordinary backend CI job
+does the same without starting Supabase.
+
+The full-stack smoke job starts both stacks. The backend points at the Compose
+TimescaleDB service, while the frontend points at Supabase Auth. A browser
+journey proves that a Supabase-issued token reaches the unchanged portfolio
+synchronization route, and a query executed inside the Compose `db` container
+proves that the resulting rows were written to TimescaleDB rather than to
+Supabase's internal database.
+
+PostgreSQL major-version upgrades use a custom-format logical backup and
+restore. The source database remains available until the restored PostgreSQL
+18 database has passed migration and data checks.

--- a/dcapal-backend/scripts/assert-smoke-data.sh
+++ b/dcapal-backend/scripts/assert-smoke-data.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BACKEND_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-postgres}"
+export POSTGRES_PASSWORD
+SMOKE_USER_EMAIL="${SMOKE_USER_EMAIL:-smoke@example.com}"
+SMOKE_PORTFOLIO_ID="${SMOKE_PORTFOLIO_ID:-11111111-1111-4111-8111-111111111111}"
+SMOKE_PORTFOLIO_NAME="${SMOKE_PORTFOLIO_NAME:-Smoke portfolio}"
+
+cd "$BACKEND_DIR"
+
+compose() {
+  local compose_files=(
+    -f docker-compose.yml
+  )
+
+  docker compose "${compose_files[@]}" "$@"
+}
+
+query() {
+  compose exec -T db psql \
+    -U postgres \
+    -d postgres \
+    -v ON_ERROR_STOP=1 \
+    -v smoke_email="$SMOKE_USER_EMAIL" \
+    -v smoke_portfolio_id="$SMOKE_PORTFOLIO_ID" \
+    -v smoke_portfolio_name="$SMOKE_PORTFOLIO_NAME" \
+    -Atq <<SQL | tr -d '[:space:]'
+$1
+SQL
+}
+
+assert_value() {
+  local description="$1"
+  local expected="$2"
+  local actual="$3"
+
+  if [[ "$actual" != "$expected" ]]; then
+    printf 'Smoke data assertion failed for %s: expected %s, got %s\n' \
+      "$description" "$expected" "$actual" >&2
+    exit 1
+  fi
+}
+
+assert_value \
+  "PostgreSQL major version" \
+  "18" \
+  "$(query "SELECT split_part(current_setting('server_version'), '.', 1)")"
+
+assert_value \
+  "authenticated smoke user" \
+  "1" \
+  "$(query "SELECT COUNT(*) FROM users WHERE email = :'smoke_email' AND role = 'authenticated'")"
+
+assert_value \
+  "saved smoke portfolio" \
+  "1" \
+  "$(query "
+    SELECT COUNT(*)
+    FROM portfolios AS p
+    JOIN users AS u ON u.id = p.user_id
+    WHERE u.email = :'smoke_email'
+      AND p.id = :'smoke_portfolio_id'::uuid
+      AND p.name = :'smoke_portfolio_name'
+      AND p.deleted = FALSE
+  ")"
+
+assert_value \
+  "saved smoke portfolio asset" \
+  "1" \
+  "$(query "
+    SELECT COUNT(*)
+    FROM portfolio_asset AS a
+    JOIN portfolios AS p ON p.id = a.portfolio_id
+    JOIN users AS u ON u.id = p.user_id
+    WHERE u.email = :'smoke_email'
+      AND p.id = :'smoke_portfolio_id'::uuid
+      AND a.symbol = 'vwce.mi'
+      AND a.asset_class = 'EQUITY'
+      AND a.currency = 'usd'
+      AND a.provider = 'YF'
+      AND a.quantity = 1
+      AND a.target_weight = 100
+      AND a.price = 100
+  ")"
+
+printf 'Timescale smoke data verified for %s and %s.\n' \
+  "$SMOKE_USER_EMAIL" "$SMOKE_PORTFOLIO_ID"

--- a/dcapal-backend/scripts/assert-smoke-data.sh
+++ b/dcapal-backend/scripts/assert-smoke-data.sh
@@ -10,6 +10,7 @@ SMOKE_PORTFOLIO_NAME="${SMOKE_PORTFOLIO_NAME:-Smoke portfolio}"
 
 cd "$BACKEND_DIR"
 
+# Runs queries against the TimescaleDB service used by the smoke test.
 compose() {
   local compose_files=(
     -f docker-compose.yml
@@ -18,6 +19,7 @@ compose() {
   docker compose "${compose_files[@]}" "$@"
 }
 
+# Returns a compact query result for the seeded smoke records.
 query() {
   compose exec -T db psql \
     -U postgres \
@@ -31,6 +33,7 @@ $1
 SQL
 }
 
+# Fails the smoke test when a database value differs from its expected value.
 assert_value() {
   local description="$1"
   local expected="$2"

--- a/dcapal-backend/scripts/render-dcapal-config.py
+++ b/dcapal-backend/scripts/render-dcapal-config.py
@@ -16,10 +16,12 @@ DEFAULT_OUTPUT = BACKEND_DIR / "dcapal.yml"
 
 
 def json_value(value: Any) -> str:
+    """Encode a configuration value as JSON for insertion into YAML."""
     return json.dumps(value, ensure_ascii=False)
 
 
 def required_environment(name: str) -> str:
+    """Return a required environment value or stop with a clear error."""
     value = os.environ.get(name)
     if not value:
         raise SystemExit(f"{name} must be set before rendering dcapal.yml")
@@ -27,6 +29,7 @@ def required_environment(name: str) -> str:
 
 
 def integer_environment(name: str, default: int) -> int:
+    """Read an integer environment value, using the supplied default when absent."""
     value = os.environ.get(name)
     if value is None:
         return default
@@ -37,6 +40,7 @@ def integer_environment(name: str, default: int) -> int:
 
 
 def boolean_environment(name: str, default: bool) -> bool:
+    """Read a boolean environment value using common shell spellings."""
     value = os.environ.get(name)
     if value is None:
         return default
@@ -49,6 +53,7 @@ def boolean_environment(name: str, default: bool) -> bool:
 
 
 def jwks_environment() -> dict[str, list[dict[str, Any]]]:
+    """Return the configured JWKS as an object containing a list of keys."""
     raw_value = os.environ.get("DCAPAL_JWT_JWKS", '{"keys": []}')
     try:
         value = json.loads(raw_value)
@@ -65,6 +70,7 @@ def jwks_environment() -> dict[str, list[dict[str, Any]]]:
 
 
 def render(template: str) -> str:
+    """Replace runtime configuration placeholders and reject unknown ones."""
     ip2location_path = os.environ.get("DCAPAL_IP2LOCATION_PATH")
     services = None
     if ip2location_path:
@@ -141,6 +147,7 @@ def render(template: str) -> str:
 
 
 def main() -> None:
+    """Render the selected configuration template to the requested output."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--template", type=Path, default=DEFAULT_TEMPLATE)
     parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)

--- a/dcapal-backend/scripts/render-dcapal-config.py
+++ b/dcapal-backend/scripts/render-dcapal-config.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Render the runtime DcaPal configuration from the checked-in template."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+DEFAULT_TEMPLATE = BACKEND_DIR / "config/dcapal/dcapal.yml"
+DEFAULT_OUTPUT = BACKEND_DIR / "dcapal.yml"
+
+
+def json_value(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False)
+
+
+def required_environment(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise SystemExit(f"{name} must be set before rendering dcapal.yml")
+    return value
+
+
+def integer_environment(name: str, default: int) -> int:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except ValueError as error:
+        raise SystemExit(f"{name} must be an integer") from error
+
+
+def boolean_environment(name: str, default: bool) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise SystemExit(f"{name} must be a boolean")
+
+
+def jwks_environment() -> dict[str, list[dict[str, Any]]]:
+    raw_value = os.environ.get("DCAPAL_JWT_JWKS", '{"keys": []}')
+    try:
+        value = json.loads(raw_value)
+    except json.JSONDecodeError as error:
+        raise SystemExit("DCAPAL_JWT_JWKS must contain valid JSON") from error
+
+    if isinstance(value, list):
+        value = {"keys": value}
+    if not isinstance(value, dict) or not isinstance(value.get("keys"), list):
+        raise SystemExit('DCAPAL_JWT_JWKS must be a JSON object with a "keys" array')
+    if not all(isinstance(key, dict) for key in value["keys"]):
+        raise SystemExit('DCAPAL_JWT_JWKS "keys" entries must be JSON objects')
+    return value
+
+
+def render(template: str) -> str:
+    ip2location_path = os.environ.get("DCAPAL_IP2LOCATION_PATH")
+    services = None
+    if ip2location_path:
+        services = {"ip": {"dbPath": ip2location_path}}
+
+    substitutions = {
+        "@@DCAPAL_PRICE_PROVIDER@@": json_value(
+            os.environ.get("DCAPAL_PRICE_PROVIDER", "kraken")
+        ),
+        "@@DCAPAL_CW_API_KEY@@": json_value(
+            os.environ.get("DCAPAL_CW_API_KEY", "CW_API_KEY")
+        ),
+        "@@DCAPAL_IP_API_KEY@@": json_value(
+            os.environ.get("DCAPAL_IP_API_KEY", "IP_API_KEY")
+        ),
+        "@@DCAPAL_CMC_API_KEY@@": json_value(
+            os.environ.get("DCAPAL_CMC_API_KEY") or None
+        ),
+        "@@DCAPAL_JWT_SECRET@@": json_value(required_environment("DCAPAL_JWT_SECRET")),
+        "@@DCAPAL_JWT_JWKS@@": json_value(jwks_environment()),
+        "@@DCAPAL_SERVICES@@": json_value(services),
+        "@@DCAPAL_LOG_LEVEL@@": json_value(
+            os.environ.get("DCAPAL_LOG_LEVEL", "dcapal_backend=info,tower_http=debug")
+        ),
+        "@@DCAPAL_LOG_FILE@@": json_value(
+            os.environ.get("DCAPAL_LOG_FILE", "data/dcapal/dcapal.log")
+        ),
+        "@@DCAPAL_LOG_ENABLE_STDOUT@@": json_value(
+            boolean_environment("DCAPAL_LOG_ENABLE_STDOUT", True)
+        ),
+        "@@DCAPAL_WEB_HOSTNAME@@": json_value(
+            os.environ.get("DCAPAL_WEB_HOSTNAME", "127.0.0.1")
+        ),
+        "@@DCAPAL_WEB_PORT@@": str(integer_environment("DCAPAL_WEB_PORT", 8080)),
+        "@@DCAPAL_METRICS_HOSTNAME@@": json_value(
+            os.environ.get("DCAPAL_METRICS_HOSTNAME", "127.0.0.1")
+        ),
+        "@@DCAPAL_METRICS_PORT@@": str(
+            integer_environment("DCAPAL_METRICS_PORT", 9000)
+        ),
+        "@@DCAPAL_REDIS_HOSTNAME@@": json_value(
+            os.environ.get("DCAPAL_REDIS_HOSTNAME", "127.0.0.1")
+        ),
+        "@@DCAPAL_REDIS_PORT@@": str(integer_environment("DCAPAL_REDIS_PORT", 6379)),
+        "@@DCAPAL_REDIS_USER@@": json_value(
+            os.environ.get("DCAPAL_REDIS_USER", "dcapal")
+        ),
+        "@@DCAPAL_REDIS_PASSWORD@@": json_value(
+            os.environ.get("DCAPAL_REDIS_PASSWORD", "dcapal")
+        ),
+        "@@DCAPAL_POSTGRES_HOSTNAME@@": json_value(
+            os.environ.get("DCAPAL_POSTGRES_HOSTNAME", "127.0.0.1")
+        ),
+        "@@DCAPAL_POSTGRES_PORT@@": str(
+            integer_environment("DCAPAL_POSTGRES_PORT", 5433)
+        ),
+        "@@DCAPAL_POSTGRES_USER@@": json_value(
+            os.environ.get("DCAPAL_POSTGRES_USER", "postgres")
+        ),
+        "@@DCAPAL_POSTGRES_PASSWORD@@": json_value(
+            os.environ.get("DCAPAL_POSTGRES_PASSWORD", "postgres")
+        ),
+        "@@DCAPAL_POSTGRES_DATABASE@@": json_value(
+            os.environ.get("DCAPAL_POSTGRES_DATABASE", "postgres")
+        ),
+    }
+
+    for placeholder, value in substitutions.items():
+        template = template.replace(placeholder, value)
+
+    if "@@" in template:
+        raise SystemExit("template contains an unknown or unrendered placeholder")
+    return template
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--template", type=Path, default=DEFAULT_TEMPLATE)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    args = parser.parse_args()
+
+    rendered = render(args.template.read_text(encoding="utf-8"))
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(rendered, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/dcapal-backend/scripts/verify-postgres-upgrade.sh
+++ b/dcapal-backend/scripts/verify-postgres-upgrade.sh
@@ -32,8 +32,14 @@ wait_for_database() {
   local name="$1"
 
   for _ in $(seq 1 90); do
-    if docker exec "$name" pg_isready -U postgres -d postgres >/dev/null 2>&1; then
-      return 0
+    if docker logs "$name" 2>&1 |
+      grep -F 'PostgreSQL init process complete; ready for start up.' >/dev/null \
+      && docker exec "$name" psql \
+        -v ON_ERROR_STOP=1 \
+        -U postgres \
+        -d postgres \
+        -c 'SELECT 1' >/dev/null 2>&1; then
+        return 0
     fi
     sleep 1
   done

--- a/dcapal-backend/scripts/verify-postgres-upgrade.sh
+++ b/dcapal-backend/scripts/verify-postgres-upgrade.sh
@@ -9,6 +9,7 @@ PASSWORD="${PG_UPGRADE_PASSWORD:-pg-upgrade-test}"
 SOURCE_IMAGE="${PG17_IMAGE:-timescale/timescaledb-ha:pg17}"
 TARGET_IMAGE="${PG18_IMAGE:-timescale/timescaledb-ha:pg18.4-ts2.28.3-all-oss}"
 
+# Removes the disposable source and target databases and their temporary files.
 cleanup() {
   docker rm -f "$SOURCE_NAME" "$TARGET_NAME" >/dev/null 2>&1 || true
   rm -rf "$TEMP_DIR"
@@ -16,6 +17,7 @@ cleanup() {
 
 trap cleanup EXIT
 
+# Starts a disposable PostgreSQL database from the requested Timescale image.
 start_database() {
   local name="$1"
   local image="$2"
@@ -28,6 +30,7 @@ start_database() {
     "$image" >/dev/null
 }
 
+# Waits until the database has completed initialization and accepts queries.
 wait_for_database() {
   local name="$1"
 
@@ -49,10 +52,12 @@ wait_for_database() {
   exit 1
 }
 
+# Returns the host port Docker mapped to the container's PostgreSQL port.
 mapped_port() {
   docker port "$1" 5432/tcp | head -n 1 | awk -F: '{print $NF}'
 }
 
+# Runs the packaged DcaPal migrations against a supplied database URL.
 run_migrations() {
   local database_url="$1"
 
@@ -60,6 +65,7 @@ run_migrations() {
   DATABASE_URL="$database_url" cargo run --quiet -p migration
 }
 
+# Restores a custom-format dump while leaving Timescale-owned catalog data intact.
 restore_dump() {
   local name="$1"
   local dump_path="$2"

--- a/dcapal-backend/scripts/verify-postgres-upgrade.sh
+++ b/dcapal-backend/scripts/verify-postgres-upgrade.sh
@@ -65,11 +65,13 @@ restore_dump() {
   local dump_path="$2"
   local restore_list="$TEMP_DIR/${name}-restore.list"
 
-  # The PostgreSQL 18 image already provisions TimescaleDB. Exclude only its
+  # TimescaleDB extensions are owned by the target image. Exclude only their
   # extension metadata from the PostgreSQL 17 archive before restoring it.
   docker exec -i "$name" pg_restore --list < "$dump_path" |
     sed -e '/EXTENSION - timescaledb$/d' \
         -e '/COMMENT - EXTENSION timescaledb$/d' \
+        -e '/EXTENSION - timescaledb_toolkit$/d' \
+        -e '/COMMENT - EXTENSION timescaledb_toolkit$/d' \
     > "$restore_list"
   docker exec -i "$name" sh -c 'cat > /tmp/dcapal-restore.list' < "$restore_list"
   docker exec -i "$name" pg_restore \

--- a/dcapal-backend/scripts/verify-postgres-upgrade.sh
+++ b/dcapal-backend/scripts/verify-postgres-upgrade.sh
@@ -71,7 +71,8 @@ restore_dump() {
     -U postgres \
     -d postgres \
     --no-owner \
-    --exit-on-error
+    --exit-on-error \
+    < "$dump_path"
 }
 
 start_database "$SOURCE_NAME" "$SOURCE_IMAGE"

--- a/dcapal-backend/scripts/verify-postgres-upgrade.sh
+++ b/dcapal-backend/scripts/verify-postgres-upgrade.sh
@@ -68,10 +68,7 @@ restore_dump() {
   # TimescaleDB extensions are owned by the target image. Exclude only their
   # extension metadata from the PostgreSQL 17 archive before restoring it.
   docker exec -i "$name" pg_restore --list < "$dump_path" |
-    sed -e '/EXTENSION - timescaledb$/d' \
-        -e '/COMMENT - EXTENSION timescaledb$/d' \
-        -e '/EXTENSION - timescaledb_toolkit$/d' \
-        -e '/COMMENT - EXTENSION timescaledb_toolkit$/d' \
+    sed -E '/EXTENSION .*timescaledb(_toolkit)?/d' \
     > "$restore_list"
   docker exec -i "$name" sh -c 'cat > /tmp/dcapal-restore.list' < "$restore_list"
   docker exec -i "$name" pg_restore \

--- a/dcapal-backend/scripts/verify-postgres-upgrade.sh
+++ b/dcapal-backend/scripts/verify-postgres-upgrade.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dcapal-pg-upgrade.XXXXXX")"
+SOURCE_NAME="dcapal-pg17-upgrade-$$"
+TARGET_NAME="dcapal-pg18-upgrade-$$"
+PASSWORD="${PG_UPGRADE_PASSWORD:-pg-upgrade-test}"
+SOURCE_IMAGE="${PG17_IMAGE:-timescale/timescaledb-ha:pg17}"
+TARGET_IMAGE="${PG18_IMAGE:-timescale/timescaledb-ha:pg18.4-ts2.28.3-all-oss}"
+
+cleanup() {
+  docker rm -f "$SOURCE_NAME" "$TARGET_NAME" >/dev/null 2>&1 || true
+  rm -rf "$TEMP_DIR"
+}
+
+trap cleanup EXIT
+
+start_database() {
+  local name="$1"
+  local image="$2"
+
+  docker run \
+    --detach \
+    --name "$name" \
+    --publish-all \
+    --env POSTGRES_PASSWORD="$PASSWORD" \
+    "$image" >/dev/null
+}
+
+wait_for_database() {
+  local name="$1"
+
+  for _ in $(seq 1 90); do
+    if docker exec "$name" pg_isready -U postgres -d postgres >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  docker logs "$name" >&2 || true
+  printf 'Timed out waiting for %s to accept PostgreSQL connections.\n' "$name" >&2
+  exit 1
+}
+
+mapped_port() {
+  docker port "$1" 5432/tcp | head -n 1 | awk -F: '{print $NF}'
+}
+
+run_migrations() {
+  local database_url="$1"
+
+  cd "$ROOT_DIR"
+  DATABASE_URL="$database_url" cargo run --quiet -p migration
+}
+
+start_database "$SOURCE_NAME" "$SOURCE_IMAGE"
+wait_for_database "$SOURCE_NAME"
+SOURCE_PORT="$(mapped_port "$SOURCE_NAME")"
+SOURCE_URL="postgresql://postgres:${PASSWORD}@127.0.0.1:${SOURCE_PORT}/postgres"
+
+run_migrations "$SOURCE_URL"
+
+docker exec -i "$SOURCE_NAME" psql -v ON_ERROR_STOP=1 -U postgres -d postgres <<'SQL'
+INSERT INTO users (id, email, role)
+VALUES ('22222222-2222-4222-8222-222222222222', 'upgrade@example.com', 'authenticated');
+
+INSERT INTO portfolios (id, user_id, name, currency, last_updated_at)
+VALUES (
+    '33333333-3333-4333-8333-333333333333',
+    '22222222-2222-4222-8222-222222222222',
+    'Upgrade portfolio',
+    'usd',
+    '2026-01-01T00:00:00Z'
+);
+
+INSERT INTO portfolio_asset (
+    id,
+    symbol,
+    portfolio_id,
+    name,
+    asset_class,
+    currency,
+    provider,
+    quantity,
+    target_weight,
+    price,
+    average_buy_price
+)
+VALUES (
+    '44444444-4444-4444-8444-444444444444',
+    'vwce.mi',
+    '33333333-3333-4333-8333-333333333333',
+    'Upgrade asset',
+    'EQUITY',
+    'usd',
+    'YF',
+    1,
+    100,
+    100,
+    100
+);
+SQL
+
+docker exec "$SOURCE_NAME" pg_dump \
+  -U postgres \
+  -d postgres \
+  --format=custom \
+  --no-owner > "$TEMP_DIR/dcapal.dump"
+
+start_database "$TARGET_NAME" "$TARGET_IMAGE"
+wait_for_database "$TARGET_NAME"
+TARGET_PORT="$(mapped_port "$TARGET_NAME")"
+TARGET_URL="postgresql://postgres:${PASSWORD}@127.0.0.1:${TARGET_PORT}/postgres"
+
+docker exec -i "$TARGET_NAME" pg_restore \
+  -U postgres \
+  -d postgres \
+  --no-owner \
+  --exit-on-error < "$TEMP_DIR/dcapal.dump"
+
+run_migrations "$TARGET_URL"
+
+TARGET_VERSION="$(docker exec "$TARGET_NAME" psql -Atqc "SHOW server_version_num" -U postgres -d postgres)"
+if [[ "$TARGET_VERSION" != 18* ]]; then
+  printf 'Expected PostgreSQL 18 after restore, got %s.\n' "$TARGET_VERSION" >&2
+  exit 1
+fi
+
+TARGET_EXTENSION_COUNT="$(docker exec "$TARGET_NAME" psql -Atqc \
+  "SELECT COUNT(*) FROM pg_extension WHERE extname = 'timescaledb'" \
+  -U postgres -d postgres)"
+if [[ "$TARGET_EXTENSION_COUNT" != "1" ]]; then
+  printf 'Expected TimescaleDB to be installed after restore.\n' >&2
+  exit 1
+fi
+
+TARGET_ROW_COUNT="$(docker exec "$TARGET_NAME" psql -Atqc \
+  "SELECT COUNT(*) FROM portfolios WHERE id = '33333333-3333-4333-8333-333333333333'" \
+  -U postgres -d postgres)"
+if [[ "$TARGET_ROW_COUNT" != "1" ]]; then
+  printf 'Expected the representative portfolio to survive the restore.\n' >&2
+  exit 1
+fi
+
+docker exec -i "$TARGET_NAME" psql -v ON_ERROR_STOP=1 -U postgres -d postgres <<'SQL'
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM users
+        WHERE id = '22222222-2222-4222-8222-222222222222'
+          AND email = 'upgrade@example.com'
+          AND role = 'authenticated'
+    ) THEN
+        RAISE EXCEPTION 'restored user is missing or changed';
+    END IF;
+
+    IF (
+        SELECT COUNT(*)
+        FROM portfolios AS p
+        JOIN users AS u ON u.id = p.user_id
+        WHERE p.id = '33333333-3333-4333-8333-333333333333'
+          AND u.id = '22222222-2222-4222-8222-222222222222'
+          AND p.name = 'Upgrade portfolio'
+          AND p.currency = 'usd'
+          AND p.deleted = FALSE
+    ) <> 1 THEN
+        RAISE EXCEPTION 'restored linked portfolio is missing or changed';
+    END IF;
+
+    IF (
+        SELECT COUNT(*)
+        FROM portfolio_asset AS a
+        JOIN portfolios AS p ON p.id = a.portfolio_id
+        WHERE a.id = '44444444-4444-4444-8444-444444444444'
+          AND p.id = '33333333-3333-4333-8333-333333333333'
+          AND a.symbol = 'vwce.mi'
+          AND a.name = 'Upgrade asset'
+          AND a.asset_class = 'EQUITY'
+          AND a.currency = 'usd'
+          AND a.provider = 'YF'
+          AND a.quantity = 1
+          AND a.target_weight = 100
+          AND a.price = 100
+          AND a.average_buy_price = 100
+    ) <> 1 THEN
+        RAISE EXCEPTION 'restored portfolio asset is missing or changed';
+    END IF;
+
+    IF (SELECT COUNT(*) FROM _sqlx_migrations) < 4
+       OR EXISTS (SELECT 1 FROM _sqlx_migrations WHERE success = FALSE) THEN
+        RAISE EXCEPTION 'migration history is incomplete or contains a failed migration';
+    END IF;
+END
+$$;
+SQL
+
+printf 'PostgreSQL 17 to 18 custom-format restore verified successfully.\n'

--- a/dcapal-backend/scripts/verify-postgres-upgrade.sh
+++ b/dcapal-backend/scripts/verify-postgres-upgrade.sh
@@ -66,7 +66,7 @@ restore_dump() {
         -e '/COMMENT - EXTENSION timescaledb$/d' \
     > "$restore_list"
   docker exec -i "$name" sh -c 'cat > /tmp/dcapal-restore.list' < "$restore_list"
-  docker exec "$name" pg_restore \
+  docker exec -i "$name" pg_restore \
     --use-list=/tmp/dcapal-restore.list \
     -U postgres \
     -d postgres \

--- a/dcapal-backend/scripts/verify-postgres-upgrade.sh
+++ b/dcapal-backend/scripts/verify-postgres-upgrade.sh
@@ -54,6 +54,26 @@ run_migrations() {
   DATABASE_URL="$database_url" cargo run --quiet -p migration
 }
 
+restore_dump() {
+  local name="$1"
+  local dump_path="$2"
+  local restore_list="$TEMP_DIR/${name}-restore.list"
+
+  # The PostgreSQL 18 image already provisions TimescaleDB. Exclude only its
+  # extension metadata from the PostgreSQL 17 archive before restoring it.
+  docker exec -i "$name" pg_restore --list < "$dump_path" |
+    sed -e '/EXTENSION - timescaledb$/d' \
+        -e '/COMMENT - EXTENSION timescaledb$/d' \
+    > "$restore_list"
+  docker exec -i "$name" sh -c 'cat > /tmp/dcapal-restore.list' < "$restore_list"
+  docker exec "$name" pg_restore \
+    --use-list=/tmp/dcapal-restore.list \
+    -U postgres \
+    -d postgres \
+    --no-owner \
+    --exit-on-error
+}
+
 start_database "$SOURCE_NAME" "$SOURCE_IMAGE"
 wait_for_database "$SOURCE_NAME"
 SOURCE_PORT="$(mapped_port "$SOURCE_NAME")"
@@ -113,11 +133,7 @@ wait_for_database "$TARGET_NAME"
 TARGET_PORT="$(mapped_port "$TARGET_NAME")"
 TARGET_URL="postgresql://postgres:${PASSWORD}@127.0.0.1:${TARGET_PORT}/postgres"
 
-docker exec -i "$TARGET_NAME" pg_restore \
-  -U postgres \
-  -d postgres \
-  --no-owner \
-  --exit-on-error < "$TEMP_DIR/dcapal.dump"
+restore_dump "$TARGET_NAME" "$TEMP_DIR/dcapal.dump"
 
 run_migrations "$TARGET_URL"
 

--- a/dcapal-backend/scripts/verify-postgres-upgrade.sh
+++ b/dcapal-backend/scripts/verify-postgres-upgrade.sh
@@ -65,10 +65,14 @@ restore_dump() {
   local dump_path="$2"
   local restore_list="$TEMP_DIR/${name}-restore.list"
 
-  # TimescaleDB extensions are owned by the target image. Exclude only their
-  # extension metadata from the PostgreSQL 17 archive before restoring it.
+  # TimescaleDB extensions and their internal catalog data are owned by the
+  # target image. Exclude their archive entries before restoring it. The dump
+  # also excludes this data at creation time; this list keeps the restore safe
+  # for an archive created before that flag was added.
   docker exec -i "$name" pg_restore --list < "$dump_path" |
-    sed -E '/EXTENSION .*timescaledb(_toolkit)?/d' \
+    sed -E \
+      -e '/EXTENSION .*timescaledb(_toolkit)?/d' \
+      -e '/TABLE DATA .*_timescaledb_(catalog|config)/d' \
     > "$restore_list"
   docker exec -i "$name" sh -c 'cat > /tmp/dcapal-restore.list' < "$restore_list"
   docker exec -i "$name" pg_restore \
@@ -132,7 +136,10 @@ docker exec "$SOURCE_NAME" pg_dump \
   -U postgres \
   -d postgres \
   --format=custom \
-  --no-owner > "$TEMP_DIR/dcapal.dump"
+  --no-owner \
+  --exclude-table-data='_timescaledb_catalog.*' \
+  --exclude-table-data='_timescaledb_config.*' \
+  > "$TEMP_DIR/dcapal.dump"
 
 start_database "$TARGET_NAME" "$TARGET_IMAGE"
 wait_for_database "$TARGET_NAME"

--- a/dcapal-frontend/README.md
+++ b/dcapal-frontend/README.md
@@ -31,9 +31,9 @@ cd dcapal-frontend
 pnpm dev
 ```
 
-## E2E smoke tests
+## E2E tests
 
-Run Playwright smoke tests with deterministic MSW fixtures for backend APIs
+The default Playwright journeys use deterministic MSW fixtures for backend APIs
 (`/api/assets/*`, `/api/price/*`, import endpoints, and sync endpoints):
 
 ```shell
@@ -41,3 +41,49 @@ pnpm frontend:test:e2e
 ```
 
 These smoke tests do not require local backend containers.
+
+The full-stack browser smoke uses the browser, local Supabase Auth, the
+frontend development server, the backend container, and the TimescaleDB Compose
+service.
+Start the local full stack with one command. It starts Supabase, reads its
+signing keys, renders the ignored backend `dcapal.yml`, and starts the
+TimescaleDB, Redis, and backend containers:
+
+```shell
+make local-up
+```
+
+Capture the local Supabase values and export them before running Playwright:
+
+```shell
+cd dcapal-backend
+eval "$(npx supabase status --workdir ./config -o env)"
+export SUPABASE_URL="$API_URL"
+export SUPABASE_ANON_KEY="$ANON_KEY"
+export SUPABASE_SERVICE_ROLE_KEY="$SERVICE_ROLE_KEY"
+export VITE_SUPABASE_URL="$API_URL"
+export VITE_SUPABASE_ANON_KEY="$ANON_KEY"
+cd ..
+```
+
+The service-role key is used only by the local test setup to create the
+disposable smoke user. Supabase's own PostgreSQL instance is not used for
+DcaPal migrations or application data.
+
+Run the full-stack browser smoke with:
+
+```shell
+pnpm frontend:test:e2e:smoke
+```
+
+The journey seeds one local portfolio, waits for the frontend's actual
+`POST /api/v1/sync/portfolios` request, and verifies that Supabase Auth accepts
+the browser session. In CI, the following Timescale assertion runs after the
+browser test:
+
+```shell
+SMOKE_USER_EMAIL=smoke@example.com \
+SMOKE_PORTFOLIO_ID=11111111-1111-4111-8111-111111111111 \
+SMOKE_PORTFOLIO_NAME="Smoke portfolio" \
+dcapal-backend/scripts/assert-smoke-data.sh
+```

--- a/dcapal-frontend/package.json
+++ b/dcapal-frontend/package.json
@@ -14,6 +14,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:e2e": "playwright test",
+    "test:e2e:smoke": "playwright test --config=playwright.smoke.config.js",
     "test:e2e:coverage": "FRONTEND_COVERAGE=1 playwright test --project=coverage-chromium --project=coverage-mobile --workers=1",
     "coverage:report": "node scripts/coverage-report.mjs"
   },

--- a/dcapal-frontend/playwright.config.js
+++ b/dcapal-frontend/playwright.config.js
@@ -26,6 +26,7 @@ const coverageProjects =
  */
 module.exports = defineConfig({
   testDir: "./tests",
+  testIgnore: "**/smoke.spec.ts",
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/dcapal-frontend/playwright.smoke.config.js
+++ b/dcapal-frontend/playwright.smoke.config.js
@@ -1,0 +1,34 @@
+// @ts-check
+const path = require("node:path");
+const { defineConfig, devices } = require("@playwright/test");
+
+module.exports = defineConfig({
+  testDir: "./tests",
+  testMatch: "**/smoke.spec.ts",
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: [["html", { open: "never" }]],
+  globalSetup: require.resolve("./tests/support/smoke.globalSetup.js"),
+  use: {
+    baseURL: "http://127.0.0.1:3000",
+    storageState: path.resolve(
+      __dirname,
+      "test-results/smoke/storage-state.json"
+    ),
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "smoke-chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "REACT_APP_E2E_MSW=0 pnpm run dev:ci",
+    url: "http://127.0.0.1:3000",
+    timeout: 120000,
+    reuseExistingServer: false,
+  },
+});

--- a/dcapal-frontend/tests/smoke.spec.ts
+++ b/dcapal-frontend/tests/smoke.spec.ts
@@ -12,6 +12,13 @@ const isPath = (url: string, pathname: string): boolean => {
   return new URL(url).pathname === pathname;
 };
 
+/*
+ * GIVEN the global setup has prepared a real Supabase session and the browser
+ * has a seeded portfolio
+ * WHEN /allocate opens
+ * THEN Supabase returns the seeded user, the frontend sends an authenticated
+ * POST /api/v1/sync/portfolios request, and the expected portfolio is included
+ */
 test("syncs a Supabase session through the frontend", async ({ page }) => {
   await seedPersistedState(page, {
     portfolios: { [smokePortfolio.id]: smokePortfolio },

--- a/dcapal-frontend/tests/smoke.spec.ts
+++ b/dcapal-frontend/tests/smoke.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "@playwright/test";
+
+import { makePortfolio, seedPersistedState } from "./support/state";
+
+const smokePortfolio = makePortfolio({
+  id: "11111111-1111-4111-8111-111111111111",
+  name: "Smoke portfolio",
+  lastUpdatedAt: "2026-01-01T00:00:00.000Z",
+});
+
+const isPath = (url: string, pathname: string): boolean => {
+  return new URL(url).pathname === pathname;
+};
+
+test("syncs a Supabase session through the frontend", async ({ page }) => {
+  await seedPersistedState(page, {
+    portfolios: { [smokePortfolio.id]: smokePortfolio },
+    selected: smokePortfolio.id,
+    step: 10,
+  });
+
+  const authUserResponse = page.waitForResponse((response) => {
+    return (
+      response.request().method() === "GET" &&
+      isPath(response.url(), "/auth/v1/user")
+    );
+  });
+  const syncRequest = page.waitForRequest((request) => {
+    return (
+      request.method() === "POST" &&
+      isPath(request.url(), "/api/v1/sync/portfolios")
+    );
+  });
+  const syncResponse = page.waitForResponse((response) => {
+    return (
+      response.request().method() === "POST" &&
+      isPath(response.url(), "/api/v1/sync/portfolios")
+    );
+  });
+
+  await page.goto("/allocate");
+
+  const [authResponse, request, response] = await Promise.all([
+    authUserResponse,
+    syncRequest,
+    syncResponse,
+  ]);
+
+  expect(authResponse.status()).toBe(200);
+  await expect(authResponse.json()).resolves.toMatchObject({
+    email: process.env.SMOKE_USER_EMAIL || "smoke@example.com",
+  });
+
+  expect(request.headers().authorization).toMatch(/^Bearer\s+\S+/);
+  expect(request.postDataJSON()).toMatchObject({
+    portfolios: [
+      expect.objectContaining({
+        id: smokePortfolio.id,
+        name: smokePortfolio.name,
+        assets: [expect.objectContaining({ symbol: "vwce.mi" })],
+      }),
+    ],
+    deletedPortfolios: [],
+  });
+  expect(response.status()).toBe(200);
+  await expect(page.getByTestId("route-allocate")).toBeVisible();
+});

--- a/dcapal-frontend/tests/support/smoke.globalSetup.js
+++ b/dcapal-frontend/tests/support/smoke.globalSetup.js
@@ -1,6 +1,5 @@
 const fs = require("node:fs");
 const path = require("node:path");
-const { createClient } = require("@supabase/supabase-js");
 
 const FRONTEND_ORIGIN = "http://127.0.0.1:3000";
 const DEFAULT_SUPABASE_URL = "http://127.0.0.1:54321";
@@ -20,6 +19,30 @@ const userMetadata = (email) => ({
   name: DEFAULT_USER_NAME,
 });
 
+const requestJson = async (url, options) => {
+  const response = await fetch(url, options);
+  const responseText = await response.text();
+  let responseBody;
+
+  try {
+    responseBody = responseText ? JSON.parse(responseText) : undefined;
+  } catch {
+    responseBody = undefined;
+  }
+
+  if (!response.ok) {
+    const message =
+      responseBody?.msg ||
+      responseBody?.message ||
+      responseBody?.error_description ||
+      responseText ||
+      response.statusText;
+    throw new Error(`${response.status} ${message}`);
+  }
+
+  return responseBody;
+};
+
 /** Creates a repeatable local Supabase user and browser session for full-stack smoke. */
 module.exports = async (config) => {
   const supabaseUrl = requiredEnvironment(
@@ -37,59 +60,56 @@ module.exports = async (config) => {
   const email = process.env.SMOKE_USER_EMAIL || DEFAULT_USER_EMAIL;
   const password = process.env.SMOKE_USER_PASSWORD || DEFAULT_USER_PASSWORD;
 
-  const adminClient = createClient(supabaseUrl, serviceRoleKey, {
-    auth: {
-      autoRefreshToken: false,
-      persistSession: false,
-      detectSessionInUrl: false,
-    },
-  });
-
-  const { data: userData, error: listError } =
-    await adminClient.auth.admin.listUsers({ page: 1, perPage: 1000 });
-  if (listError)
-    throw new Error(`Could not list smoke users: ${listError.message}`);
+  const adminHeaders = {
+    apikey: serviceRoleKey,
+    Authorization: `Bearer ${serviceRoleKey}`,
+    "Content-Type": "application/json",
+  };
+  const authApiUrl = `${supabaseUrl}/auth/v1`;
+  const userData = await requestJson(
+    `${authApiUrl}/admin/users?page=1&per_page=1000`,
+    { headers: adminHeaders }
+  );
 
   const users = userData?.users || [];
   const existingUser = users.find((user) => user.email === email);
   const metadata = userMetadata(email);
 
   if (existingUser) {
-    const { error } = await adminClient.auth.admin.updateUserById(
-      existingUser.id,
-      {
+    await requestJson(`${authApiUrl}/admin/users/${existingUser.id}`, {
+      method: "PUT",
+      headers: adminHeaders,
+      body: JSON.stringify({
         password,
         email_confirm: true,
         user_metadata: metadata,
-      }
-    );
-    if (error) throw new Error(`Could not reset smoke user: ${error.message}`);
-  } else {
-    const { error } = await adminClient.auth.admin.createUser({
-      email,
-      password,
-      email_confirm: true,
-      user_metadata: metadata,
+      }),
     });
-    if (error) throw new Error(`Could not create smoke user: ${error.message}`);
+  } else {
+    await requestJson(`${authApiUrl}/admin/users`, {
+      method: "POST",
+      headers: adminHeaders,
+      body: JSON.stringify({
+        email,
+        password,
+        email_confirm: true,
+        user_metadata: metadata,
+      }),
+    });
   }
 
-  const authClient = createClient(supabaseUrl, anonKey, {
-    auth: {
-      autoRefreshToken: false,
-      persistSession: false,
-      detectSessionInUrl: false,
-    },
-  });
-  const {
-    data: { session },
-    error: signInError,
-  } = await authClient.auth.signInWithPassword({ email, password });
-  if (signInError || !session) {
-    throw new Error(
-      `Could not sign in the smoke user: ${signInError?.message || "no session returned"}`
-    );
-  }
+  const session = await requestJson(
+    `${authApiUrl}/token?grant_type=password`,
+    {
+      method: "POST",
+      headers: {
+        apikey: anonKey,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ email, password }),
+    }
+  );
+  if (!session?.access_token) throw new Error("Supabase returned no access token.");
 
   const supabaseHost = new URL(supabaseUrl).hostname.split(".")[0];
   const storageKey = `sb-${supabaseHost}-auth-token`;

--- a/dcapal-frontend/tests/support/smoke.globalSetup.js
+++ b/dcapal-frontend/tests/support/smoke.globalSetup.js
@@ -19,6 +19,11 @@ const userMetadata = (email) => ({
   name: DEFAULT_USER_NAME,
 });
 
+/**
+ * Sends an HTTP request and parses its JSON response.
+ *
+ * Throws an error with the response details when the request is unsuccessful.
+ */
 const requestJson = async (url, options) => {
   const response = await fetch(url, options);
   const responseText = await response.text();
@@ -43,7 +48,12 @@ const requestJson = async (url, options) => {
   return responseBody;
 };
 
-/** Creates a repeatable local Supabase user and browser session for full-stack smoke. */
+/**
+ * Prepares the browser state for the full-stack smoke journey.
+ *
+ * The setup resets or creates the fixed test user, obtains a password session
+ * from Supabase Auth, and writes that session to the browser storage state.
+ */
 module.exports = async (config) => {
   const supabaseUrl = requiredEnvironment(
     "SUPABASE_URL",
@@ -98,18 +108,16 @@ module.exports = async (config) => {
     });
   }
 
-  const session = await requestJson(
-    `${authApiUrl}/token?grant_type=password`,
-    {
-      method: "POST",
-      headers: {
-        apikey: anonKey,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ email, password }),
-    }
-  );
-  if (!session?.access_token) throw new Error("Supabase returned no access token.");
+  const session = await requestJson(`${authApiUrl}/token?grant_type=password`, {
+    method: "POST",
+    headers: {
+      apikey: anonKey,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ email, password }),
+  });
+  if (!session?.access_token)
+    throw new Error("Supabase returned no access token.");
 
   const supabaseHost = new URL(supabaseUrl).hostname.split(".")[0];
   const storageKey = `sb-${supabaseHost}-auth-token`;

--- a/dcapal-frontend/tests/support/smoke.globalSetup.js
+++ b/dcapal-frontend/tests/support/smoke.globalSetup.js
@@ -1,0 +1,119 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const { createClient } = require("@supabase/supabase-js");
+
+const FRONTEND_ORIGIN = "http://127.0.0.1:3000";
+const DEFAULT_SUPABASE_URL = "http://127.0.0.1:54321";
+const DEFAULT_USER_EMAIL = "smoke@example.com";
+const DEFAULT_USER_PASSWORD = "smoke-password-123456";
+const DEFAULT_USER_NAME = "Smoke User";
+
+const requiredEnvironment = (name, fallback) => {
+  const value = process.env[name] || fallback;
+  if (!value) throw new Error(`The full-stack smoke setup requires ${name}.`);
+  return value;
+};
+
+const userMetadata = (email) => ({
+  email,
+  full_name: DEFAULT_USER_NAME,
+  name: DEFAULT_USER_NAME,
+});
+
+/** Creates a repeatable local Supabase user and browser session for full-stack smoke. */
+module.exports = async (config) => {
+  const supabaseUrl = requiredEnvironment(
+    "SUPABASE_URL",
+    process.env.VITE_SUPABASE_URL || DEFAULT_SUPABASE_URL
+  );
+  const anonKey = requiredEnvironment(
+    "SUPABASE_ANON_KEY",
+    process.env.VITE_SUPABASE_ANON_KEY
+  );
+  const serviceRoleKey = requiredEnvironment(
+    "SUPABASE_SERVICE_ROLE_KEY",
+    undefined
+  );
+  const email = process.env.SMOKE_USER_EMAIL || DEFAULT_USER_EMAIL;
+  const password = process.env.SMOKE_USER_PASSWORD || DEFAULT_USER_PASSWORD;
+
+  const adminClient = createClient(supabaseUrl, serviceRoleKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+      detectSessionInUrl: false,
+    },
+  });
+
+  const { data: userData, error: listError } =
+    await adminClient.auth.admin.listUsers({ page: 1, perPage: 1000 });
+  if (listError)
+    throw new Error(`Could not list smoke users: ${listError.message}`);
+
+  const users = userData?.users || [];
+  const existingUser = users.find((user) => user.email === email);
+  const metadata = userMetadata(email);
+
+  if (existingUser) {
+    const { error } = await adminClient.auth.admin.updateUserById(
+      existingUser.id,
+      {
+        password,
+        email_confirm: true,
+        user_metadata: metadata,
+      }
+    );
+    if (error) throw new Error(`Could not reset smoke user: ${error.message}`);
+  } else {
+    const { error } = await adminClient.auth.admin.createUser({
+      email,
+      password,
+      email_confirm: true,
+      user_metadata: metadata,
+    });
+    if (error) throw new Error(`Could not create smoke user: ${error.message}`);
+  }
+
+  const authClient = createClient(supabaseUrl, anonKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+      detectSessionInUrl: false,
+    },
+  });
+  const {
+    data: { session },
+    error: signInError,
+  } = await authClient.auth.signInWithPassword({ email, password });
+  if (signInError || !session) {
+    throw new Error(
+      `Could not sign in the smoke user: ${signInError?.message || "no session returned"}`
+    );
+  }
+
+  const supabaseHost = new URL(supabaseUrl).hostname.split(".")[0];
+  const storageKey = `sb-${supabaseHost}-auth-token`;
+  const storageStatePath = path.resolve(
+    config.configDir || process.cwd(),
+    "test-results/smoke/storage-state.json"
+  );
+  fs.mkdirSync(path.dirname(storageStatePath), { recursive: true });
+  fs.writeFileSync(
+    storageStatePath,
+    JSON.stringify(
+      {
+        cookies: [],
+        origins: [
+          {
+            origin: FRONTEND_ORIGIN,
+            localStorage: [
+              { name: storageKey, value: JSON.stringify(session) },
+            ],
+          },
+        ],
+      },
+      null,
+      2
+    )
+  );
+};

--- a/docs/research/timescaledb-production-local-ci-parity.md
+++ b/docs/research/timescaledb-production-local-ci-parity.md
@@ -2,6 +2,15 @@
 
 Research date: 2026-08-05
 
+Implementation update (2026-08-13): issue #794 adopts the TimescaleDB
+PostgreSQL 18 application-database contract and keeps Supabase as a separate
+authentication stack. The durable decision and upgrade procedure are recorded
+in [backend ADR 0002](../../dcapal-backend/docs/adr/0002-timescaledb-application-database.md)
+and the [upgrade runbook](../runbooks/timescaledb-postgres-upgrade.md).
+
+The numbered findings below describe the pre-implementation baseline where
+they refer to the former PostgreSQL 17 image or Supabase-backed test setup.
+
 ## Context
 
 - Ticket: [Research: Verify TimescaleDB local and CI parity](https://github.com/dcapal/dcapal/issues/757)
@@ -11,7 +20,11 @@ This is a research finding, not a product-code change. It uses the current
 repository source and first-party TimescaleDB, SQLx, and Supabase documentation.
 Redis is explicitly outside this epic.
 
-## Executive findings
+## Historical findings (pre-issue #794 baseline)
+
+The findings below preserve the research evidence that led to issue #794.
+They describe the repository before the implementation and are not current
+acceptance criteria where the implementation update above says otherwise.
 
 1. **The repository already has a suitable local TimescaleDB service.** The base
    Compose file uses `timescale/timescaledb-ha:pg17`, exposes PostgreSQL only to
@@ -75,7 +88,8 @@ Redis is explicitly outside this epic.
    and [migration ADR](https://github.com/dcapal/dcapal/blob/f652260de11204971f95b6235ffc40cf812911a1/dcapal-backend/docs/adr/0001-sqlx-persistence-and-migrations.md#decision)
 
 7. **Ordinary CI should use the Timescale Compose database for backend tests.**
-   The current `backend-test` job installs the Supabase CLI, starts Supabase,
+   The pre-issue backend test job (now `build-test-backend`) installed the
+   Supabase CLI, started Supabase,
    and runs `make test-backend`; the Makefile defaults `DATABASE_URL` to
    Supabase's `127.0.0.1:54322` endpoint. This makes ordinary SQLx tests depend
    on the wrong database implementation for a Timescale contract. The ordinary
@@ -88,8 +102,9 @@ Redis is explicitly outside this epic.
    and [SQLx test attribute documentation](https://docs.rs/sqlx/latest/sqlx/attr.test.html)
 
 8. **Supabase should be isolated to a smoke-test boundary.** The existing
-   `backend-smoke-test` already starts Supabase separately, configures the
-   application to use the Compose `db` service, and starts the Timescale/Redis
+   The pre-issue smoke job (now `test-e2e-smoke`) already started Supabase
+   separately, configured the application to use the Compose `db` service, and
+   started the Timescale/Redis
    application stack with `docker compose ... up --wait`. That job is the right
    place to retain Supabase checks that exercise Supabase-specific auth or local
    service wiring. It should not be the database oracle for ordinary repository
@@ -110,14 +125,18 @@ Redis is explicitly outside this epic.
    [backend runtime wiring](https://github.com/dcapal/dcapal/blob/f652260de11204971f95b6235ffc40cf812911a1/dcapal-backend/src/lib.rs#L125-L145),
    and [current PostgreSQL-only integration tests](https://github.com/dcapal/dcapal/blob/f652260de11204971f95b6235ffc40cf812911a1/dcapal-backend/tests/portfolio_repository.rs#L58-L129)
 
-## Recommended boundary for the implementation ticket
+## Future Timescale work outside issue #794
 
-The next implementation should make the database contract explicit in one
-forward SQLx migration:
+Issue #794 deliberately does not add a Timescale-specific migration, create
+hypertables, or change the application schema. Timescale provisioning owns
+extension availability. The following ideas remain separate future work and
+must not be read as requirements for the current database upgrade.
 
-- Use `CREATE EXTENSION IF NOT EXISTS timescaledb` only if production ownership
-  and permissions allow it; otherwise fail clearly during deployment rather than
-  silently falling back to plain PostgreSQL.
+If a future schema introduces time-series observations, its design should:
+
+- Keep extension provisioning outside application migrations, and verify the
+  operational prerequisite in the deployment process rather than adding
+  `CREATE EXTENSION` to issue #794.
 - Create the observation table with a non-null `timestamptz` partition column and
   an application-level series key. Choose the unique key with the time column
   included, for example `(series_id, observed_at)`.
@@ -130,15 +149,16 @@ forward SQLx migration:
 - Keep repository tests on `#[sqlx::test(migrations = "./migrations", fixtures(...))]`.
   SQLx applies migrations and fixtures in isolated test databases; fixture order
   must continue to satisfy foreign keys. [SQLx test and fixture guidance](https://docs.rs/sqlx/latest/sqlx/attr.test.html)
-- Change ordinary backend CI to start the Timescale Compose `db` service and
-  point SQLx at it. Keep Supabase startup and any Supabase-specific checks in an
-  explicitly named smoke job. Keep Redis out of the migration and ordinary SQLx
-  test setup.
+- Preserve the issue #794 boundary in any future schema work: ordinary backend
+  CI uses the Timescale Compose `db` service, while Supabase remains an
+  explicitly named authentication-smoke dependency.
 
-## Operational acceptance criteria
+## Future-work validation ideas
 
-The implementation is ready when a clean checkout can demonstrate all of the
-following:
+These checks apply only if the separate hypertable/schema work is taken up:
+
+A future implementation is ready when a clean checkout can demonstrate all of
+the following:
 
 1. The Compose database reports healthy only after PostgreSQL accepts both
    readiness and a real query, and `SELECT extname, extversion FROM pg_extension`
@@ -153,9 +173,7 @@ following:
    existing Compose application stack, while failure logs identify which service
    failed.
 
-The production decision that remains open is not whether SQLx can talk to
-TimescaleDB; it can. The decision is whether the production PostgreSQL service
-will be explicitly pinned and operated as a TimescaleDB-capable target. If that
-cannot be guaranteed, use ordinary PostgreSQL partitioning for the first
-production schema and treat TimescaleDB as an optional local/CI profile rather
-than claiming production/local parity.
+For issue #794, the production image contract and PostgreSQL upgrade procedure
+are recorded in ADR 0002 and the upgrade runbook. Any future decision about
+Timescale-specific schema objects should be made separately from that accepted
+application-database boundary.

--- a/docs/runbooks/timescaledb-postgres-upgrade.md
+++ b/docs/runbooks/timescaledb-postgres-upgrade.md
@@ -323,7 +323,7 @@ configuration, then runs:
     docker compose -f docker-compose.yml \
       -f ./docker/docker-compose.prod.yml down
     docker compose -f docker-compose.yml \
-      -f ./docker/docker-compose.prod.yml up -d
+      -f ./docker/docker-compose.prod.yml up -d --wait --wait-timeout 180
 
 After this runbook completes, that sequence is safe because data/db is a
 PostgreSQL 18 data directory. The next deployment does not need to restore the

--- a/docs/runbooks/timescaledb-postgres-upgrade.md
+++ b/docs/runbooks/timescaledb-postgres-upgrade.md
@@ -1,69 +1,360 @@
-# PostgreSQL and TimescaleDB upgrade runbook
+# PostgreSQL 17 to 18 TimescaleDB upgrade runbook
 
-This runbook covers the DcaPal application database. It does not cover the
-Supabase authentication database, which is a separate service and must not
-receive DcaPal migrations.
+This runbook covers the DcaPal application database on a host where DcaPal is
+deployed with Docker Compose. It does not cover the Supabase authentication
+database. Supabase is a separate service and must not receive DcaPal
+migrations.
 
-## Current target
+The procedure is a one-time physical cutover from a PostgreSQL 17 data
+directory to a new PostgreSQL 18 data directory. PostgreSQL major-version
+data directories are not reusable across major versions. Use the custom-format
+dump and restore below; do not point the PostgreSQL 18 container at the old
+directory.
 
-The application database uses:
+## Deployment layout
+
+The deployment workflow writes this unpinned image tag to the db service:
 
     timescale/timescaledb-ha:pg18.4-ts2.28.3-all-oss
 
-The Compose service is named `db`. Local development exposes it on host port
-5433; the backend container connects to it on port 5432 inside the Compose
-network.
+The Compose service is named db. The container is normally named db in
+production and db-dev in development. The database data directory is the
+host path ./data/db/, mounted into the container at
+/home/postgres/pgdata/data.
 
-## Before an upgrade
+The backend connects to db:5432 on the Compose network. A deployment may
+publish PostgreSQL on a host port such as 45827; that port is only for
+host-side access and must not be used in the backend connection string. Local
+development currently uses host port 5433 through
+docker/docker-compose.dev.yml.
 
-Confirm that the source database is healthy and that the application has a
-recent backup. Use PostgreSQL's custom dump format so the restore can be
-performed by `pg_restore` and objects can be recreated in dependency order:
+## Safety rules
 
-    pg_dump --format=custom --no-owner \
-      --file=dcapal-pre-pg18.dump "$SOURCE_DATABASE_URL"
+- Schedule a maintenance window and stop the backend before taking the dump.
+- Keep the PostgreSQL 17 data directory and the dump until the PostgreSQL 18
+  deployment has passed its application checks.
+- Never run docker compose down -v during this procedure.
+- Never run PostgreSQL down migrations as a rollback. They remove schema
+  objects and may remove data.
+- Do not put database passwords directly into commands or this document. Use
+  the existing deployed Compose configuration, dcapal.env, or a protected
+  shell environment.
+- The globals dump below is a recovery artifact. Do not replay it blindly over
+  the fresh database: the initialization scripts in config/db/init own the
+  deployment roles and their password configuration.
 
-Keep the source PostgreSQL 17 database available until the restore and
-application checks are complete. Do not use SQLx down migrations as a rollback;
-they remove schema objects and can remove data.
+## One-time cutover on the deployed host
 
-## Restore into PostgreSQL 18
+### 1. Connect and inspect the deployment
 
-Start a clean PostgreSQL 18 TimescaleDB target, then restore the custom dump:
+SSH to the host and change to the directory configured as DCAPAL_DIR or
+DCAPAL_DIR_DEV in the deployment secrets. The commands below use the
+development-style path names from the example deployment; use the actual
+directory on the host.
 
-    pg_restore --no-owner --exit-on-error \
-      --dbname="$TARGET_DATABASE_URL" dcapal-pre-pg18.dump
+    ssh <deployment-user>@<deployment-host>
+    cd <DCAPAL_DIR>
 
-Run the current SQLx migrations. The migration runner should complete without
-adding unexpected pending migrations:
+Run the following setup in the same shell as the remaining commands. It uses
+the deployment override when that file is present, so it works with the base
+database/Redis Compose file and with the full stack written by
+.github/workflows/deploy.yml:
 
-    DATABASE_URL="$TARGET_DATABASE_URL" cargo run -p migration
+    set -euo pipefail
 
-Verify the target before switching the application:
+    export DCAPAL_DIR="$PWD"
+    export PG18_IMAGE='timescale/timescaledb-ha:pg18.4-ts2.28.3-all-oss'
+    export STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+    export BACKUP_DIR="$DCAPAL_DIR/data/db-backups/$STAMP"
+    export OLD_DATA_DIR="$DCAPAL_DIR/data/db-pg17-$STAMP"
+    export COMPOSE_BACKUP="$DCAPAL_DIR/docker-compose.yml.pg17-$STAMP"
 
-    psql "$TARGET_DATABASE_URL" -c \
-      "SHOW server_version; SELECT extname, extversion FROM pg_extension WHERE extname = 'timescaledb';"
+    compose() {
+      if [[ -f docker/docker-compose.prod.yml ]]; then
+        docker compose -f docker-compose.yml -f docker/docker-compose.prod.yml "$@"
+      else
+        docker compose -f docker-compose.yml "$@"
+      fi
+    }
 
-Also verify representative user, saved portfolio, and portfolio asset counts,
-then start the backend and confirm its normal health check succeeds.
+    compose config >/dev/null
+    compose config --services
+    compose ps
+    test -d "$DCAPAL_DIR/data/db"
 
-The repository includes a disposable proof of this procedure:
+The full-stack deployment override should be present before the migration
+step because it supplies the backend image and dcapal.env. If the dcapal
+service is not listed by compose config --services, stop here and obtain the
+current deployment override before continuing.
+
+    if ! compose config --services | grep -Fxq dcapal; then
+      echo 'The dcapal service is not present in the deployment Compose files.' >&2
+      echo 'Obtain docker/docker-compose.prod.yml before continuing.' >&2
+      exit 1
+    fi
+
+    test -f dcapal.env
+
+Confirm that the running database is PostgreSQL 17 before changing anything:
+
+    SOURCE_MAJOR="$(compose exec -T db psql -U postgres -d postgres -Atqc \
+      'SHOW server_version_num' | tr -d '[:space:]')"
+    case "$SOURCE_MAJOR" in
+      17*) ;;
+      *)
+        echo "Expected PostgreSQL 17, found $SOURCE_MAJOR" >&2
+        exit 1
+        ;;
+    esac
+
+    compose exec -T db psql -U postgres -d postgres -c \
+      "SHOW server_version; SELECT extname, extversion
+       FROM pg_extension WHERE extname = 'timescaledb';"
+
+### 2. Stop writes and create the backups
+
+Stop the backend service but leave the database running long enough to create
+the backups:
+
+    mkdir -p "$BACKUP_DIR"
+    chmod 700 "$BACKUP_DIR"
+    compose stop dcapal
+
+Create a custom-format database dump and a globals backup. The custom dump
+contains the DcaPal schema, migration history, users, portfolios, assets, and
+other application data. The globals file records role definitions without
+including role passwords:
+
+    compose exec -T db pg_dump \
+      -U postgres \
+      -d postgres \
+      --format=custom \
+      --no-owner \
+      > "$BACKUP_DIR/dcapal-pg17.dump"
+
+    compose exec -T db pg_dumpall \
+      -U postgres \
+      --globals-only \
+      --no-role-passwords \
+      > "$BACKUP_DIR/pg-globals.sql"
+
+    chmod 600 "$BACKUP_DIR/dcapal-pg17.dump" "$BACKUP_DIR/pg-globals.sql"
+    test -s "$BACKUP_DIR/dcapal-pg17.dump"
+    test -s "$BACKUP_DIR/pg-globals.sql"
+    compose exec -T db pg_restore --list \
+      < "$BACKUP_DIR/dcapal-pg17.dump" \
+      >/dev/null
+
+Record representative counts for the post-restore comparison:
+
+    compose exec -T db psql -U postgres -d postgres -Atqc \
+      "SELECT 'users', count(*) FROM users
+       UNION ALL SELECT 'portfolios', count(*) FROM portfolios
+       UNION ALL SELECT 'portfolio_asset', count(*) FROM portfolio_asset
+       ORDER BY 1" \
+      | tr -d '\r' \
+      > "$BACKUP_DIR/pre-cutover-counts.txt"
+
+### 3. Replace the PostgreSQL 17 data directory
+
+Stop and remove the Compose containers without removing bind-mounted data:
+
+    compose down
+
+Save the PostgreSQL 17 directory by renaming it. Create a new empty directory
+at the path used by the Compose bind mount:
+
+    mv "$DCAPAL_DIR/data/db" "$OLD_DATA_DIR"
+    mkdir "$DCAPAL_DIR/data/db"
+    chmod 700 "$DCAPAL_DIR/data/db"
+
+Save the current Compose file, then change only the database image to the
+PostgreSQL 18 TimescaleDB tag. The deployment workflow will write the same
+image on the next deploy, so this also keeps the host correct during the
+intervening period:
+
+    cp -p docker-compose.yml "$COMPOSE_BACKUP"
+
+    sed -i \
+      's#timescale/timescaledb-ha:pg17#timescale/timescaledb-ha:pg18.4-ts2.28.3-all-oss#g' \
+      docker-compose.yml
+
+    grep -Fq "image: $PG18_IMAGE" \
+      docker-compose.yml
+
+Do not start the backend yet. Pull and start only the fresh database:
+
+    compose pull db
+    compose up -d --no-deps --wait --wait-timeout 180 db
+
+Verify that the new data directory is PostgreSQL 18 and that the TimescaleDB
+extension is available:
+
+    TARGET_MAJOR="$(compose exec -T db psql -U postgres -d postgres -Atqc \
+      'SHOW server_version_num' | tr -d '[:space:]')"
+    case "$TARGET_MAJOR" in
+      18*) ;;
+      *)
+        echo "Expected PostgreSQL 18, found $TARGET_MAJOR" >&2
+        exit 1
+        ;;
+    esac
+
+    compose exec -T db psql -v ON_ERROR_STOP=1 \
+      -U postgres -d postgres -c \
+      "SELECT current_setting('server_version') AS server_version,
+              extname,
+              extversion
+       FROM pg_extension
+       WHERE extname = 'timescaledb';"
+
+The fresh database initialization must have run the role scripts in
+config/db/init. Verify the application login role from dcapal.env exists
+before restoring the dump. If it does not, stop and restore the role using the
+same deployment secret; do not continue with a missing application role.
+
+    APP_USER="$(sed -n 's/^POSTGRES_USER=//p' dcapal.env)"
+    test -n "$APP_USER"
+    compose exec -T db psql -v ON_ERROR_STOP=1 \
+      -U postgres -d postgres \
+      -v app_user="$APP_USER" \
+      -c "SELECT rolname, rolcanlogin
+          FROM pg_roles
+          WHERE rolname = :'app_user';"
+
+### 4. Restore data and run DcaPal migrations
+
+Restore the PostgreSQL 17 custom dump into the empty PostgreSQL 18 database:
+
+    compose exec -T db pg_restore \
+      -U postgres \
+      -d postgres \
+      --no-owner \
+      --exit-on-error \
+      < "$BACKUP_DIR/dcapal-pg17.dump"
+
+Run the migration binary packaged in the DcaPal backend image. The command
+uses the Compose-internal db:5432 address and the credentials already loaded
+by dcapal.env; it does not expose a password in the command line:
+
+    compose run --rm --no-deps \
+      --entrypoint /bin/sh \
+      dcapal \
+      -ceu '
+        export DATABASE_URL="postgresql://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST:$POSTGRES_PORT/$POSTGRES_DB"
+        exec /var/dcapal/dcapal-backend/bin/migration
+      '
+
+The migration command should complete successfully. Running it again when the
+backend starts is expected and should report no new work unless the deployed
+application image contains a newer migration.
+
+### 5. Start and verify the complete stack
+
+Start the full Compose stack and wait for its health checks:
+
+    compose up -d --wait --wait-timeout 180
+    compose ps
+
+Verify the PostgreSQL version, migration history, and representative DcaPal
+tables:
+
+    compose exec -T db psql -v ON_ERROR_STOP=1 -U postgres -d postgres -c \
+      "SELECT current_setting('server_version') AS server_version;
+       SELECT extname, extversion
+       FROM pg_extension WHERE extname = 'timescaledb';
+       SELECT count(*) AS applied_migrations
+       FROM _sqlx_migrations WHERE success = TRUE;
+       SELECT count(*) AS failed_migrations
+       FROM _sqlx_migrations WHERE success = FALSE;
+       SELECT 'users' AS table_name, count(*) FROM users
+       UNION ALL SELECT 'portfolios', count(*) FROM portfolios
+       UNION ALL SELECT 'portfolio_asset', count(*) FROM portfolio_asset
+       ORDER BY 1;"
+
+Compare the three table counts with
+$BACKUP_DIR/pre-cutover-counts.txt. Also verify the normal backend health
+endpoint through the host port configured for the deployment. If the backend
+uses the default API port, for example:
+
+    curl --fail http://127.0.0.1:8080/
+
+Finally, confirm that the Compose configuration still contains the exact
+PostgreSQL 18 image:
+
+    compose config --images | grep -Fx "$PG18_IMAGE"
+
+Keep $BACKUP_DIR, $OLD_DATA_DIR, and $COMPOSE_BACKUP until the normal
+application validation and the next deployment have completed successfully.
+
+## Handoff to deploy.yml
+
+The deployment workflow uploads a generated docker-compose.yml containing
+the same PostgreSQL 18 image, uploads the production Compose override and
+configuration, then runs:
+
+    docker compose -f docker-compose.yml \
+      -f ./docker/docker-compose.prod.yml pull
+    docker compose -f docker-compose.yml \
+      -f ./docker/docker-compose.prod.yml down
+    docker compose -f docker-compose.yml \
+      -f ./docker/docker-compose.prod.yml up -d
+
+After this runbook completes, that sequence is safe because data/db is a
+PostgreSQL 18 data directory. The next deployment does not need to restore the
+database again. It will run the backend startup migration against the existing
+TimescaleDB database and then start the application.
+
+## Rollback
+
+### Failure before PostgreSQL 18 receives writes
+
+If verification fails before the backend has accepted writes, stop the stack,
+move the unused PostgreSQL 18 directory aside, restore the retained
+PostgreSQL 17 directory, and restore the saved Compose file:
+
+    compose down
+    mv "$DCAPAL_DIR/data/db" "$DCAPAL_DIR/data/db-pg18-failed-$STAMP"
+    mv "$OLD_DATA_DIR" "$DCAPAL_DIR/data/db"
+    cp -p "$COMPOSE_BACKUP" docker-compose.yml
+    compose pull db
+    compose up -d --wait --wait-timeout 180
+
+Do not run down migrations. Keep the failed PostgreSQL 18 directory and the
+dump for investigation.
+
+### Failure after PostgreSQL 18 has received writes
+
+The retained PostgreSQL 17 directory is now stale and must not be attached as
+if it contains those writes. Prefer fixing the PostgreSQL 18 deployment
+forward. If a PostgreSQL 17 rollback is required, create a fresh PostgreSQL 17
+data directory, restore the pre-cutover custom dump into it, rerun the
+migrations, and then start the backend. This restores the pre-cutover state and
+does not preserve writes made after the cutover.
+
+    compose down
+    mv "$DCAPAL_DIR/data/db" "$DCAPAL_DIR/data/db-pg18-failed-$STAMP"
+    cp -p "$COMPOSE_BACKUP" docker-compose.yml
+    mkdir "$DCAPAL_DIR/data/db"
+    chmod 700 "$DCAPAL_DIR/data/db"
+    compose pull db
+    compose up -d --no-deps --wait --wait-timeout 180 db
+    compose exec -T db pg_restore \
+      -U postgres -d postgres --no-owner --exit-on-error \
+      < "$BACKUP_DIR/dcapal-pg17.dump"
+
+Run the packaged migration command from the backend service, then start and
+verify the full stack. Treat any post-cutover writes that are not present in
+the dump as lost unless they are recovered separately.
+
+## Disposable PostgreSQL 17 to 18 proof
+
+For a local or CI-only verification of the procedure, run:
 
     ./dcapal-backend/scripts/verify-postgres-upgrade.sh
 
-The proof starts TimescaleDB PostgreSQL 17 and 18 containers, runs the SQLx
-migrations, inserts representative rows, creates a custom-format dump, restores
-it into PostgreSQL 18, reruns migrations, and checks the extension and data.
-
-## Cutover and rollback
-
-After the target passes verification, point the Compose-managed deployment at
-the PostgreSQL 18 database and restart the backend. Keep the source backup and
-database until the deployment has passed its normal health and application
-checks.
-
-If the target fails before cutover, leave the source untouched, fix the target,
-and repeat the restore. If the failure happens after cutover, stop the backend,
-point it back to the retained PostgreSQL 17 database or restore, and restart
-it. Investigate the failed target before retrying; do not run destructive down
-migrations against production.
+The proof starts disposable TimescaleDB PostgreSQL 17 and 18 containers, runs
+the SQLx migrations, inserts representative users, portfolios, and assets,
+creates a custom-format dump, restores it into PostgreSQL 18, reruns the
+migrations, and checks the extension and restored data. It does not touch the
+deployed host or the Supabase PostgreSQL instance.

--- a/docs/runbooks/timescaledb-postgres-upgrade.md
+++ b/docs/runbooks/timescaledb-postgres-upgrade.md
@@ -81,11 +81,13 @@ database/Redis Compose file and with the full stack written by
       local dump_path="$1"
       local restore_list="$BACKUP_DIR/restore.list"
 
-      # The PostgreSQL 18 image already provisions TimescaleDB. Restore the
-      # application archive without replaying only that extension metadata.
+      # TimescaleDB extensions are owned by the target image. Restore the
+      # application archive without replaying their extension metadata.
       compose exec -T db pg_restore --list < "$dump_path" |
         sed -e '/EXTENSION - timescaledb$/d' \
             -e '/COMMENT - EXTENSION timescaledb$/d' \
+            -e '/EXTENSION - timescaledb_toolkit$/d' \
+            -e '/COMMENT - EXTENSION timescaledb_toolkit$/d' \
         > "$restore_list"
       chmod 600 "$restore_list"
       compose exec -T db sh -c 'cat > /tmp/dcapal-restore.list' < "$restore_list"
@@ -246,8 +248,9 @@ same deployment secret; do not continue with a missing application role.
 ### 4. Restore data and run DcaPal migrations
 
 Restore the PostgreSQL 17 custom dump into the empty PostgreSQL 18 database.
-The restore list omits only the TimescaleDB extension and its comment because
-the PostgreSQL 18 TimescaleDB image has already created that extension:
+The restore list omits only the TimescaleDB and TimescaleDB Toolkit extension
+metadata because extension availability is owned by the PostgreSQL 18
+TimescaleDB image:
 
     restore_dump "$BACKUP_DIR/dcapal-pg17.dump"
 

--- a/docs/runbooks/timescaledb-postgres-upgrade.md
+++ b/docs/runbooks/timescaledb-postgres-upgrade.md
@@ -1,0 +1,69 @@
+# PostgreSQL and TimescaleDB upgrade runbook
+
+This runbook covers the DcaPal application database. It does not cover the
+Supabase authentication database, which is a separate service and must not
+receive DcaPal migrations.
+
+## Current target
+
+The application database uses:
+
+    timescale/timescaledb-ha:pg18.4-ts2.28.3-all-oss
+
+The Compose service is named `db`. Local development exposes it on host port
+5433; the backend container connects to it on port 5432 inside the Compose
+network.
+
+## Before an upgrade
+
+Confirm that the source database is healthy and that the application has a
+recent backup. Use PostgreSQL's custom dump format so the restore can be
+performed by `pg_restore` and objects can be recreated in dependency order:
+
+    pg_dump --format=custom --no-owner \
+      --file=dcapal-pre-pg18.dump "$SOURCE_DATABASE_URL"
+
+Keep the source PostgreSQL 17 database available until the restore and
+application checks are complete. Do not use SQLx down migrations as a rollback;
+they remove schema objects and can remove data.
+
+## Restore into PostgreSQL 18
+
+Start a clean PostgreSQL 18 TimescaleDB target, then restore the custom dump:
+
+    pg_restore --no-owner --exit-on-error \
+      --dbname="$TARGET_DATABASE_URL" dcapal-pre-pg18.dump
+
+Run the current SQLx migrations. The migration runner should complete without
+adding unexpected pending migrations:
+
+    DATABASE_URL="$TARGET_DATABASE_URL" cargo run -p migration
+
+Verify the target before switching the application:
+
+    psql "$TARGET_DATABASE_URL" -c \
+      "SHOW server_version; SELECT extname, extversion FROM pg_extension WHERE extname = 'timescaledb';"
+
+Also verify representative user, saved portfolio, and portfolio asset counts,
+then start the backend and confirm its normal health check succeeds.
+
+The repository includes a disposable proof of this procedure:
+
+    ./dcapal-backend/scripts/verify-postgres-upgrade.sh
+
+The proof starts TimescaleDB PostgreSQL 17 and 18 containers, runs the SQLx
+migrations, inserts representative rows, creates a custom-format dump, restores
+it into PostgreSQL 18, reruns migrations, and checks the extension and data.
+
+## Cutover and rollback
+
+After the target passes verification, point the Compose-managed deployment at
+the PostgreSQL 18 database and restart the backend. Keep the source backup and
+database until the deployment has passed its normal health and application
+checks.
+
+If the target fails before cutover, leave the source untouched, fix the target,
+and repeat the restore. If the failure happens after cutover, stop the backend,
+point it back to the retained PostgreSQL 17 database or restore, and restart
+it. Investigate the failed target before retrying; do not run destructive down
+migrations against production.

--- a/docs/runbooks/timescaledb-postgres-upgrade.md
+++ b/docs/runbooks/timescaledb-postgres-upgrade.md
@@ -84,10 +84,7 @@ database/Redis Compose file and with the full stack written by
       # TimescaleDB extensions are owned by the target image. Restore the
       # application archive without replaying their extension metadata.
       compose exec -T db pg_restore --list < "$dump_path" |
-        sed -e '/EXTENSION - timescaledb$/d' \
-            -e '/COMMENT - EXTENSION timescaledb$/d' \
-            -e '/EXTENSION - timescaledb_toolkit$/d' \
-            -e '/COMMENT - EXTENSION timescaledb_toolkit$/d' \
+        sed -E '/EXTENSION .*timescaledb(_toolkit)?/d' \
         > "$restore_list"
       chmod 600 "$restore_list"
       compose exec -T db sh -c 'cat > /tmp/dcapal-restore.list' < "$restore_list"

--- a/docs/runbooks/timescaledb-postgres-upgrade.md
+++ b/docs/runbooks/timescaledb-postgres-upgrade.md
@@ -77,6 +77,26 @@ database/Redis Compose file and with the full stack written by
       fi
     }
 
+    restore_dump() {
+      local dump_path="$1"
+      local restore_list="$BACKUP_DIR/restore.list"
+
+      # The PostgreSQL 18 image already provisions TimescaleDB. Restore the
+      # application archive without replaying only that extension metadata.
+      compose exec -T db pg_restore --list < "$dump_path" |
+        sed -e '/EXTENSION - timescaledb$/d' \
+            -e '/COMMENT - EXTENSION timescaledb$/d' \
+        > "$restore_list"
+      chmod 600 "$restore_list"
+      compose exec -T db sh -c 'cat > /tmp/dcapal-restore.list' < "$restore_list"
+      compose exec -T db pg_restore \
+        --use-list=/tmp/dcapal-restore.list \
+        -U postgres \
+        -d postgres \
+        --no-owner \
+        --exit-on-error
+    }
+
     compose config >/dev/null
     compose config --services
     compose ps
@@ -224,14 +244,11 @@ same deployment secret; do not continue with a missing application role.
 
 ### 4. Restore data and run DcaPal migrations
 
-Restore the PostgreSQL 17 custom dump into the empty PostgreSQL 18 database:
+Restore the PostgreSQL 17 custom dump into the empty PostgreSQL 18 database.
+The restore list omits only the TimescaleDB extension and its comment because
+the PostgreSQL 18 TimescaleDB image has already created that extension:
 
-    compose exec -T db pg_restore \
-      -U postgres \
-      -d postgres \
-      --no-owner \
-      --exit-on-error \
-      < "$BACKUP_DIR/dcapal-pg17.dump"
+    restore_dump "$BACKUP_DIR/dcapal-pg17.dump"
 
 Run the migration binary packaged in the DcaPal backend image. The command
 uses the Compose-internal db:5432 address and the credentials already loaded
@@ -339,9 +356,7 @@ does not preserve writes made after the cutover.
     chmod 700 "$DCAPAL_DIR/data/db"
     compose pull db
     compose up -d --no-deps --wait --wait-timeout 180 db
-    compose exec -T db pg_restore \
-      -U postgres -d postgres --no-owner --exit-on-error \
-      < "$BACKUP_DIR/dcapal-pg17.dump"
+    restore_dump "$BACKUP_DIR/dcapal-pg17.dump"
 
 Run the packaged migration command from the backend service, then start and
 verify the full stack. Treat any post-cutover writes that are not present in

--- a/docs/runbooks/timescaledb-postgres-upgrade.md
+++ b/docs/runbooks/timescaledb-postgres-upgrade.md
@@ -94,7 +94,8 @@ database/Redis Compose file and with the full stack written by
         -U postgres \
         -d postgres \
         --no-owner \
-        --exit-on-error
+        --exit-on-error \
+        < "$dump_path"
     }
 
     compose config >/dev/null

--- a/docs/runbooks/timescaledb-postgres-upgrade.md
+++ b/docs/runbooks/timescaledb-postgres-upgrade.md
@@ -81,10 +81,12 @@ database/Redis Compose file and with the full stack written by
       local dump_path="$1"
       local restore_list="$BACKUP_DIR/restore.list"
 
-      # TimescaleDB extensions are owned by the target image. Restore the
-      # application archive without replaying their extension metadata.
+      # TimescaleDB extensions and their internal catalog data are owned by the
+      # target image. Restore the application archive without replaying them.
       compose exec -T db pg_restore --list < "$dump_path" |
-        sed -E '/EXTENSION .*timescaledb(_toolkit)?/d' \
+        sed -E \
+          -e '/EXTENSION .*timescaledb(_toolkit)?/d' \
+          -e '/TABLE DATA .*_timescaledb_(catalog|config)/d' \
         > "$restore_list"
       chmod 600 "$restore_list"
       compose exec -T db sh -c 'cat > /tmp/dcapal-restore.list' < "$restore_list"
@@ -150,6 +152,8 @@ including role passwords:
       -d postgres \
       --format=custom \
       --no-owner \
+      --exclude-table-data='_timescaledb_catalog.*' \
+      --exclude-table-data='_timescaledb_config.*' \
       > "$BACKUP_DIR/dcapal-pg17.dump"
 
     compose exec -T db pg_dumpall \
@@ -245,9 +249,12 @@ same deployment secret; do not continue with a missing application role.
 ### 4. Restore data and run DcaPal migrations
 
 Restore the PostgreSQL 17 custom dump into the empty PostgreSQL 18 database.
-The restore list omits only the TimescaleDB and TimescaleDB Toolkit extension
-metadata because extension availability is owned by the PostgreSQL 18
-TimescaleDB image:
+The dump excludes TimescaleDB and TimescaleDB Toolkit internal catalog data,
+and the restore list also removes those extension metadata and data entries.
+The target image owns this state, and the PostgreSQL 17 and 18 catalog schemas
+are not interchangeable. DcaPal does not currently own TimescaleDB
+hypertables, so this preserves all DcaPal application tables while the target
+image provisions its own extension catalog:
 
     restore_dump "$BACKUP_DIR/dcapal-pg17.dump"
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "frontend:typecheck": "pnpm --filter @dcapal/frontend typecheck",
     "frontend:test": "pnpm --filter @dcapal/frontend test",
     "frontend:test:e2e": "pnpm --filter @dcapal/frontend test:e2e",
+    "frontend:test:e2e:smoke": "pnpm --filter @dcapal/frontend test:e2e:smoke",
     "frontend:test:e2e:coverage": "pnpm --filter @dcapal/frontend test:e2e:coverage",
     "frontend:coverage:report": "pnpm --filter @dcapal/frontend coverage:report"
   }


### PR DESCRIPTION
## Summary

Switches DcaPal application data and migrations to the unpinned TimescaleDB PostgreSQL 18 image while keeping Supabase dedicated to authentication. Replaces the health-only smoke coverage with a real browser journey and documents the operational upgrade path.

## Related Issues

Closes #794

## Changes Made

- Adds a test-only Compose override with temporary container-managed TimescaleDB storage while preserving the local and production `./data/db` bind mounts.
- Makes backend tests wait on Compose health checks and updates deployment startup to use `--wait`.
- Documents the real Supabase-authenticated Playwright journey and backend JWT/JWKS behavior.
- Adds PostgreSQL 17 to 18 custom-format upgrade verification and Timescale smoke-data assertions.
- Updates the deployment upgrade runbook and repository agent guidance.

## Motivation

The application database must run on TimescaleDB PostgreSQL 18, while Supabase remains an authentication dependency rather than the DcaPal application database. The smoke test now exercises the browser, real Supabase Auth, the backend sync endpoint, and the Timescale rows that result from that request.

## Design decisions

The development and production bind mounts remain unchanged. CI uses a separate Compose override without the bind mount so its database is disposable and does not depend on host filesystem ownership. The public `POST /api/v1/sync/portfolios` route and wire format remain unchanged. The PostgreSQL upgrade proof excludes Timescale-owned catalog data and reruns DcaPal migrations on the PostgreSQL 18 target.

## Validation

- **Backend database scenario:** `GIVEN` the TimescaleDB PostgreSQL 18 service is started through the test Compose override, `WHEN` `make test-backend` runs and the service is stopped with `make backend-db-down`, `THEN` repository and migration tests pass against the temporary application database.
- **Upgrade scenario:** `GIVEN` representative users, portfolios, and assets in a disposable PostgreSQL 17 Timescale container, `WHEN` the custom-format dump is restored into PostgreSQL 18 and migrations rerun, `THEN` the representative rows, migration history, PostgreSQL 18 version, and TimescaleDB extension are verified.
- **Deterministic browser scenario:** `GIVEN` the MSW frontend test configuration, `WHEN` the existing Playwright journeys run, `THEN` all 114 tests pass.
- **Authenticated browser scenario:** `GIVEN` local Supabase has issued a password session for the seeded smoke user and the browser has a seeded portfolio, `WHEN` `/allocate` opens, `THEN` the frontend receives the authenticated user, sends the bearer-authenticated sync request, and the Timescale assertion finds the expected user, portfolio, and asset rows.
- **Configuration scenario:** `GIVEN` the development and test Compose files plus the deployment workflow, `WHEN` Compose and YAML configuration validation runs, `THEN` both configurations parse, the test database has no `data/db` bind mount, and deployment waits for healthy services.

## Risk/Notes

The production and local development bind mounts are intentionally retained. The PostgreSQL 18 cutover must follow the runbook and retain the PostgreSQL 17 recovery directory and pre-cutover dump until validation completes. Supabase's own PostgreSQL instance does not receive DcaPal migrations. The pre-existing local `AGENTS.md` change is included in this commit as explicitly requested.
