### PR TITLE
chore(deps): bump nanoid to 3.3.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
       "@supabase/auth-ui-react>react-dom": "^19.2.8",
       "vite": "6.4.3",
       "js-yaml": "4.3.1",
-      "nanoid": "3.3.17"
+      "nanoid": "3.3.18"
     }
   },
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -244,7 +244,7 @@ overrides:
   '@supabase/auth-ui-react>react-dom': ^19.2.8
   vite: 6.4.3
   js-yaml: 4.3.1
-  nanoid: 3.3.17
+  nanoid: 3.3.18
 
 importers:
 
@@ -4672,8 +4672,8 @@ packages:
     resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -10621,7 +10621,7 @@ snapshots:
 
   mute-stream@3.0.0: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   negotiator@0.6.3: {}
 
@@ -11407,7 +11407,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
## Summary

Update `nanoid` to `3.3.18` to address the Dependabot vulnerability update.

## Related Issues

None.

## Changes Made

- Update the package override in `package.json`.
- Refresh the matching entries and integrity hash in `pnpm-lock.yaml`.

## Motivation

Keep the dependency version aligned with the security update while preserving the existing dependency graph.

## Design decisions

Only the dependency override and lockfile metadata were changed. No application code or runtime behavior was modified.

## Testing

Not run (not requested).

## Risk/Notes

This is a dependency-only maintenance change. CI should run the repository’s standard checks before merge.

## Final report

- Head: `feat/fix-dependabot-vulnerability-279`
- Base: `master`
- Validation: Not run (not requested).