### PR TITLE
fix(ci): fetch IP2Location database from remote R2 storage

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -147,7 +147,7 @@ jobs:
           apiToken: ${{ secrets.CF_R2_API_TOKEN }}
           accountId: ${{ secrets.CF_R2_ACCOUNT_ID }}
           workingDirectory: dcapal-backend/data/dcapal
-          command: r2 object get ip2location-db/${{ env.IP2LOCATION_FILENAME }}.zip
+          command: r2 object get ip2location-db/${{ env.IP2LOCATION_FILENAME }}.zip --remote
 
       - name: Deploy IP2Location database
         uses: appleboy/scp-action@master


### PR DESCRIPTION
## Summary

Ensure deployment retrieves the IP2Location database from remote Cloudflare R2 storage before deploying it.

## Related Issues

None

## Changes Made

- Add the `--remote` flag to the R2 object download command in `.github/workflows/deploy.yml`.

## Motivation

The deployment workflow could resolve the IP2Location object locally instead of fetching it from R2, preventing the database from being available for deployment.

## Design decisions

- Keep the existing R2 path and filename configuration unchanged.
- Limit the change to the deployment workflow command.

## Testing

- **Deployment configuration:** `GIVEN` the deployment workflow runs with valid R2 credentials, `WHEN` the IP2Location download step executes, `THEN` it fetches the configured object from remote R2 storage. Manually verified the workflow command includes `--remote`.

## Risk/Notes

- Not run (not requested). The change affects CI deployment configuration and was manually reviewed for syntax and scope.