### PR TITLE
fix(frontend): bundle optimizer workers in production

### DIFF
--- a/dcapal-frontend/package.json
+++ b/dcapal-frontend/package.json
@@ -15,6 +15,7 @@
     "test": "vitest run",
     "test:e2e": "playwright test",
     "test:e2e:smoke": "playwright test --config=playwright.smoke.config.js",
+    "test:e2e:production-mock": "playwright test --config=playwright.production-mock.config.js",
     "test:e2e:coverage": "FRONTEND_COVERAGE=1 playwright test --project=coverage-chromium --project=coverage-mobile --workers=1",
     "coverage:report": "node scripts/coverage-report.mjs"
   },

--- a/dcapal-frontend/playwright.config.js
+++ b/dcapal-frontend/playwright.config.js
@@ -26,7 +26,7 @@ const coverageProjects =
  */
 module.exports = defineConfig({
   testDir: "./tests",
-  testIgnore: "**/smoke.spec.ts",
+  testIgnore: "**/*smoke.spec.ts",
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/dcapal-frontend/playwright.production-mock.config.js
+++ b/dcapal-frontend/playwright.production-mock.config.js
@@ -1,0 +1,27 @@
+// @ts-check
+const { defineConfig, devices } = require("@playwright/test");
+
+module.exports = defineConfig({
+  testDir: "./tests",
+  testMatch: "**/production-mock.smoke.spec.ts",
+  fullyParallel: false,
+  workers: 1,
+  reporter: [["html", { open: "never" }]],
+  use: {
+    baseURL: "http://127.0.0.1:3000",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "production-mock-chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    // This verifies the deployable bundle with only backend requests mocked.
+    command: "pnpm run build && node scripts/serve-dist.mjs",
+    url: "http://127.0.0.1:3000",
+    timeout: 120000,
+    reuseExistingServer: false,
+  },
+});

--- a/dcapal-frontend/src/compute/index.test.ts
+++ b/dcapal-frontend/src/compute/index.test.ts
@@ -123,6 +123,10 @@ describe("compute boundary", () => {
 
     expect(firstResult).toBeNull();
     expect(secondResult).toBe(42);
+    expect(console.error).toHaveBeenCalledWith(
+      "Unexpected exception in dcapal-optimizer analyzer worker:",
+      expect.any(Error)
+    );
     expect(spawnMock).toHaveBeenCalledTimes(2);
     expect(terminateMock).toHaveBeenCalledTimes(1);
     expect(terminateMock).toHaveBeenCalledWith(failingRpc);

--- a/dcapal-frontend/src/compute/index.ts
+++ b/dcapal-frontend/src/compute/index.ts
@@ -39,11 +39,21 @@ const createWorkerState = <
 
 const analyzerState = createWorkerState<AnalyzerWorkerRpc>();
 const solverState = createWorkerState<SolverWorkerRpc>();
-const analyzerWorkerUrl = new URL(
-  "./workers/analyzer.worker.js",
-  import.meta.url
-);
-const solverWorkerUrl = new URL("./workers/solver.worker.js", import.meta.url);
+
+const createAnalyzerWorker = (): unknown =>
+  new Worker(
+    new URL(
+      "./workers/analyzer.worker.js",
+      import.meta.url
+    ) as unknown as string,
+    { name: "wasm-analyzer-worker" }
+  );
+
+const createSolverWorker = (): unknown =>
+  new Worker(
+    new URL("./workers/solver.worker.js", import.meta.url) as unknown as string,
+    { name: "wasm-solver-worker" }
+  );
 
 const enqueueSerialized = async <TWorker extends WorkerRpc, TResult>(
   state: WorkerState<TWorker>,
@@ -56,17 +66,13 @@ const enqueueSerialized = async <TWorker extends WorkerRpc, TResult>(
 
 const getWorker = async <TWorker extends WorkerRpc>(
   state: WorkerState<TWorker>,
-  workerUrl: URL,
-  workerName: string
+  createWorker: () => unknown
 ): Promise<TWorker> => {
   if (state.instancePromise) return state.instancePromise;
 
-  // TODO(migrate): threads' constructor types only accept string paths, but webpack worker loading uses URL.
   state.instancePromise = (
     spawn(
-      new Worker(workerUrl as unknown as string, {
-        name: workerName,
-      })
+      createWorker() as Parameters<typeof spawn>[0]
     ) as unknown as Promise<TWorker>
   ).catch((error: unknown) => {
     state.instancePromise = null;
@@ -94,12 +100,11 @@ const terminateWorkerPromise = async <TWorker extends WorkerRpc>(
 
 const runWithWorker = async <TWorker extends WorkerRpc, TResult>(
   state: WorkerState<TWorker>,
-  workerUrl: URL,
-  workerName: string,
+  createWorker: () => unknown,
   operation: (worker: TWorker) => Promise<TResult>
 ): Promise<TResult> => {
   return enqueueSerialized(state, async () => {
-    const workerPromise = getWorker(state, workerUrl, workerName);
+    const workerPromise = getWorker(state, createWorker);
 
     try {
       const worker = await workerPromise;
@@ -120,12 +125,14 @@ export const analyze = async (
   try {
     return await runWithWorker(
       analyzerState,
-      analyzerWorkerUrl,
-      "wasm-analyzer-worker",
+      createAnalyzerWorker,
       async (worker) => worker.analyzeAndSolve(assets)
     );
   } catch (error) {
-    console.error("Unexpected exception in dcapal-optimizer:", error);
+    console.error(
+      "Unexpected exception in dcapal-optimizer analyzer worker:",
+      error
+    );
     return null;
   }
 };
@@ -152,8 +159,7 @@ export const solve = async (
   try {
     return await runWithWorker(
       solverState,
-      solverWorkerUrl,
-      "wasm-solver-worker",
+      createSolverWorker,
       async (worker) =>
         worker.makeAndSolve(
           budget,
@@ -165,7 +171,10 @@ export const solve = async (
         )
     );
   } catch (error) {
-    console.error("Unexpected exception in dcapal-optimizer:", error);
+    console.error(
+      "Unexpected exception in dcapal-optimizer solver worker:",
+      error
+    );
     return null;
   }
 };

--- a/dcapal-frontend/tests/production-mock.smoke.spec.ts
+++ b/dcapal-frontend/tests/production-mock.smoke.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "./support/fixtures";
+import { seedAuthenticatedSession } from "./support/auth";
+import { makePortfolio, seedPersistedState } from "./support/state";
+
+test("a mocked production allocation loads the bundled optimizer", async ({
+  page,
+}) => {
+  /*
+   * GIVEN the production bundle uses the browser mock backend
+   * WHEN an authenticated investor opens a valid allocation at the final step
+   * THEN the bundled WASM optimizer returns an allocation without worker errors
+   */
+  const portfolio = makePortfolio({
+    id: "production-mock-allocation",
+    name: "Production mock allocation",
+    budget: 100,
+  });
+  await seedAuthenticatedSession(page);
+  await seedPersistedState(page, {
+    portfolios: { [portfolio.id]: portfolio },
+    selected: portfolio.id,
+    step: 50,
+  });
+  await page.route("**/auth/v1/user", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        id: "fixture-user",
+        aud: "authenticated",
+        role: "authenticated",
+        email: "fixture@example.com",
+        user_metadata: { name: "Fixture User" },
+      }),
+    })
+  );
+  await page.route("**/api/v1/sync/portfolios", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ updatedPortfolios: [], deletedPortfolios: [] }),
+    })
+  );
+
+  const runtimeErrors: string[] = [];
+  page.on("pageerror", (error) => {
+    runtimeErrors.push(`pageerror: ${error.message}`);
+  });
+  page.on("console", (message) => {
+    if (
+      message.type() === "error" &&
+      /dcapal-optimizer|wasm|worker/i.test(message.text())
+    ) {
+      runtimeErrors.push(`console: ${message.text()}`);
+    }
+  });
+
+  await page.goto("/allocate");
+
+  await expect(page.getByTestId("route-allocate")).toBeVisible();
+  await page.waitForTimeout(1000);
+  expect(runtimeErrors).toEqual([]);
+  await expect(
+    page.getByText(/(?:allocation is ready|allocazione è pronta)/i)
+  ).toBeVisible();
+  await expect(
+    page.getByText(/oops! (?:something bad happened|qualcosa è andato storto)/i)
+  ).toHaveCount(0);
+});

--- a/dcapal-frontend/tests/smoke.spec.ts
+++ b/dcapal-frontend/tests/smoke.spec.ts
@@ -37,7 +37,10 @@ test("a production allocation completes with the bundled optimizer", async ({
     runtimeErrors.push(`pageerror: ${error.message}`);
   });
   page.on("console", (message) => {
-    if (message.type() === "error") {
+    if (
+      message.type() === "error" &&
+      /dcapal-optimizer|wasm|worker/i.test(message.text())
+    ) {
       runtimeErrors.push(`console: ${message.text()}`);
     }
   });

--- a/dcapal-frontend/tests/smoke.spec.ts
+++ b/dcapal-frontend/tests/smoke.spec.ts
@@ -12,6 +12,48 @@ const isPath = (url: string, pathname: string): boolean => {
   return new URL(url).pathname === pathname;
 };
 
+test("a production allocation completes with the bundled optimizer", async ({
+  page,
+}) => {
+  /*
+   * GIVEN an investor has a valid portfolio and a non-zero investment budget
+   * WHEN the production allocation route opens at its final step
+   * THEN the bundled WASM optimizer produces an allocation instead of the
+   * generic error state, without reporting browser runtime errors
+   */
+  const portfolio = makePortfolio({
+    id: "allocation-smoke-portfolio",
+    name: "Allocation smoke portfolio",
+    budget: 100,
+  });
+  await seedPersistedState(page, {
+    portfolios: { [portfolio.id]: portfolio },
+    selected: portfolio.id,
+    step: 50,
+  });
+
+  const runtimeErrors: string[] = [];
+  page.on("pageerror", (error) => {
+    runtimeErrors.push(`pageerror: ${error.message}`);
+  });
+  page.on("console", (message) => {
+    if (message.type() === "error") {
+      runtimeErrors.push(`console: ${message.text()}`);
+    }
+  });
+
+  await page.goto("/allocate");
+
+  await expect(page.getByTestId("route-allocate")).toBeVisible();
+  await expect(
+    page.getByText(/(?:allocation is ready|allocazione è pronta)/i)
+  ).toBeVisible();
+  await expect(
+    page.getByText(/oops! (?:something bad happened|qualcosa è andato storto)/i)
+  ).toHaveCount(0);
+  expect(runtimeErrors).toEqual([]);
+});
+
 /*
  * GIVEN the global setup has prepared a real Supabase session and the browser
  * has a seeded portfolio

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "frontend:test": "pnpm --filter @dcapal/frontend test",
     "frontend:test:e2e": "pnpm --filter @dcapal/frontend test:e2e",
     "frontend:test:e2e:smoke": "pnpm --filter @dcapal/frontend test:e2e:smoke",
+    "frontend:test:e2e:production-mock": "pnpm --filter @dcapal/frontend test:e2e:production-mock",
     "frontend:test:e2e:coverage": "pnpm --filter @dcapal/frontend test:e2e:coverage",
     "frontend:coverage:report": "pnpm --filter @dcapal/frontend coverage:report"
   }


### PR DESCRIPTION
## Summary

Restores production bundling for the optimizer workers so allocation can load the WASM module in beta. Adds both a full-stack smoke assertion and a Docker-free production-bundle diagnostic.

## Related Issues

None

## Changes Made

- Create each `threads` worker with Webpack's literal `new Worker(new URL(..., import.meta.url))` pattern.
- Preserve worker reuse and error recovery while identifying whether the analyzer or solver failed.
- Add an allocation-success smoke scenario with a seeded portfolio and investment budget.
- Add `pnpm frontend:test:e2e:production-mock`, which builds and serves the production frontend while Playwright mocks its auth and portfolio-sync HTTP requests.

## Motivation

The previous refactor passed the worker URL through a variable. Webpack emitted a raw worker containing a bare `dcapal-optimizer-wasm` import, which browsers cannot resolve on beta. The existing smoke job did not execute an allocation. Its console assertion also failed on unrelated transient backend-sync errors, even after allocation completed successfully.

## Design decisions

The change restores the bundler-recognised worker form instead of adding another worker-bundling dependency. The public compute API and `threads` RPC behaviour remain unchanged. The local diagnostic intercepts backend HTTP calls only, so it still validates real worker chunks and WASM assets from the production build.

## Validation

- **Worker bundle:** `GIVEN` a production frontend build, `WHEN` Webpack emits the analyzer and solver workers, `THEN` it emits bundled worker chunks and a WASM asset rather than a raw bare package import; verified with `pnpm frontend:build`.
- **Compute boundary:** `GIVEN` an analyzer worker failure, `WHEN` the boundary recovers, `THEN` it logs analyzer-specific context and recreates the worker; verified with `pnpm frontend:test`.
- **Local production allocation:** `GIVEN` a seeded, authenticated browser state and mocked backend HTTP calls, `WHEN` the production bundle loads `/allocate`, `THEN` the real bundled optimizer returns allocation-ready without worker or WASM errors; verified with `pnpm frontend:test:e2e:production-mock`.
- **CI production allocation:** `GIVEN` the full smoke stack has a seeded portfolio at the final allocation step, `WHEN` the smoke job loads the production bundle, `THEN` it must render allocation-ready and have no worker or page runtime errors; registered in `tests/smoke.spec.ts` for `pnpm frontend:test:e2e:smoke`.