### PR TITLE
feat(backend): add portfolio asset schema foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,6 +883,7 @@ dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
  "migration",
+ "num_enum",
  "parking_lot",
  "redis",
  "reqwest",
@@ -2599,6 +2600,28 @@ checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ log = "0.4.33"
 metrics = "0.24.6"
 metrics-exporter-prometheus = "0.18.3"
 minilp = "0.2.2"
+num_enum = "0.7.4"
 parking_lot = "0.12.5"
 rand = "0.10.2"
 redis = { version = "1.5.0", features = ["tokio-comp"] }

--- a/dcapal-backend/crates/backend/Cargo.toml
+++ b/dcapal-backend/crates/backend/Cargo.toml
@@ -26,6 +26,7 @@ jsonwebtoken = { workspace = true }
 lazy_static = { workspace = true }
 metrics = { workspace = true }
 metrics-exporter-prometheus = { workspace = true }
+num_enum = { workspace = true }
 parking_lot = { workspace = true }
 redis = { workspace = true }
 reqwest = { workspace = true }

--- a/dcapal-backend/crates/backend/src/ports/outbound/repository/postgres/portfolio.rs
+++ b/dcapal-backend/crates/backend/src/ports/outbound/repository/postgres/portfolio.rs
@@ -48,7 +48,8 @@ impl SqlxPortfolioRepository {
     ) -> Result<Vec<PortfolioAssetRow>> {
         // Lock the current asset set so concurrent syncs cannot both reconcile it from stale data.
         let existing_assets = query_as::<_, PortfolioAssetRow>(
-            "SELECT id, symbol, portfolio_id, name, asset_class, currency, provider,
+            "SELECT id, symbol, portfolio_id, name, legacy_asset_class AS asset_class,
+                    currency, legacy_provider AS provider,
                     quantity, target_weight, price, max_fee_impact, fee_type, fee_amount,
                     fee_rate, min_fee, max_fee, average_buy_price, created_at, updated_at
              FROM portfolio_asset
@@ -71,12 +72,14 @@ impl SqlxPortfolioRepository {
             let updated = if let Some(existing_asset) = existing_asset {
                 query_as::<_, PortfolioAssetRow>(
                     "UPDATE portfolio_asset
-                     SET symbol = $2, name = $3, asset_class = $4, currency = $5,
-                         provider = $6, quantity = $7, target_weight = $8, price = $9,
+                    SET symbol = $2, name = $3, legacy_asset_class = $4, currency = $5,
+                         legacy_provider = $6, quantity = $7, target_weight = $8, price = $9,
                          average_buy_price = $10, max_fee_impact = $11, fee_type = $12,
                          fee_amount = $13, fee_rate = $14, min_fee = $15, max_fee = $16
                      WHERE id = $1
-                     RETURNING id, symbol, portfolio_id, name, asset_class, currency, provider,
+                     RETURNING id, symbol, portfolio_id, name,
+                               legacy_asset_class AS asset_class, currency,
+                               legacy_provider AS provider,
                                quantity, target_weight, price, max_fee_impact, fee_type,
                                fee_amount, fee_rate, min_fee, max_fee, average_buy_price,
                                created_at, updated_at",
@@ -102,12 +105,15 @@ impl SqlxPortfolioRepository {
             } else {
                 query_as::<_, PortfolioAssetRow>(
                     "INSERT INTO portfolio_asset
-                         (id, symbol, portfolio_id, name, asset_class, currency, provider,
+                         (id, symbol, portfolio_id, name, legacy_asset_class, currency,
+                          legacy_provider,
                           quantity, target_weight, price, average_buy_price, max_fee_impact,
                           fee_type, fee_amount, fee_rate, min_fee, max_fee)
                      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14,
                              $15, $16, $17)
-                     RETURNING id, symbol, portfolio_id, name, asset_class, currency, provider,
+                     RETURNING id, symbol, portfolio_id, name,
+                               legacy_asset_class AS asset_class, currency,
+                               legacy_provider AS provider,
                                quantity, target_weight, price, max_fee_impact, fee_type,
                                fee_amount, fee_rate, min_fee, max_fee, average_buy_price,
                                created_at, updated_at",
@@ -208,7 +214,8 @@ impl PortfolioRepository for SqlxPortfolioRepository {
 
         let portfolio_ids: Vec<Uuid> = portfolios.iter().map(|portfolio| portfolio.id).collect();
         let assets = query_as::<_, PortfolioAssetRow>(
-            "SELECT id, symbol, portfolio_id, name, asset_class, currency, provider,
+            "SELECT id, symbol, portfolio_id, name, legacy_asset_class AS asset_class,
+                    currency, legacy_provider AS provider,
                     quantity, target_weight, price, max_fee_impact, fee_type, fee_amount,
                     fee_rate, min_fee, max_fee, average_buy_price, created_at, updated_at
              FROM portfolio_asset

--- a/dcapal-backend/crates/backend/src/ports/outbound/repository/postgres/types/mod.rs
+++ b/dcapal-backend/crates/backend/src/ports/outbound/repository/postgres/types/mod.rs
@@ -5,5 +5,5 @@ mod portfolio_asset;
 mod user;
 
 pub use portfolio::PortfolioRow;
-pub use portfolio_asset::PortfolioAssetRow;
+pub use portfolio_asset::{AssetClass, PortfolioAssetRow, Provider};
 pub use user::UserRow;

--- a/dcapal-backend/crates/backend/src/ports/outbound/repository/postgres/types/portfolio_asset.rs
+++ b/dcapal-backend/crates/backend/src/ports/outbound/repository/postgres/types/portfolio_asset.rs
@@ -1,6 +1,35 @@
 use chrono::{DateTime, Utc};
+use num_enum::{IntoPrimitive, TryFromPrimitive};
 use rust_decimal::Decimal;
 use uuid::Uuid;
+
+/// The provider codes used by canonical Portfolio Asset storage.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, IntoPrimitive, TryFromPrimitive)]
+#[repr(i16)]
+pub enum Provider {
+    /// Yahoo Finance.
+    YF = 2,
+    /// Kraken.
+    Kraken = 1,
+}
+
+/// The Asset Class codes used by canonical Portfolio Asset storage.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, IntoPrimitive, TryFromPrimitive)]
+#[repr(i16)]
+pub enum AssetClass {
+    /// An unclassified or unsupported asset.
+    Other = 0,
+    /// An equity asset.
+    Equity = 1,
+    /// A bond asset.
+    Bond = 2,
+    /// Cash or cash-equivalent assets.
+    Cash = 3,
+    /// A cryptocurrency asset.
+    Crypto = 4,
+    /// A commodity asset.
+    Commodity = 5,
+}
 
 /// A row from the `portfolio_asset` table.
 #[derive(Debug, Clone, PartialEq, sqlx::FromRow)]
@@ -43,4 +72,41 @@ pub struct PortfolioAssetRow {
     pub created_at: DateTime<Utc>,
     /// When the database row was last changed.
     pub updated_at: DateTime<Utc>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provider_codes_round_trip() {
+        // GIVEN each supported Provider code, WHEN it converts to and from storage,
+        // THEN it preserves the assigned value and rejects unsupported codes.
+        assert_eq!(i16::from(Provider::Kraken), 1);
+        assert_eq!(i16::from(Provider::YF), 2);
+        assert_eq!(Provider::try_from(1), Ok(Provider::Kraken));
+        assert_eq!(Provider::try_from(2), Ok(Provider::YF));
+        assert!(Provider::try_from(0).is_err());
+    }
+
+    #[test]
+    fn asset_class_codes_round_trip() {
+        // GIVEN each supported Asset Class code, WHEN it converts to and from storage,
+        // THEN it preserves the assigned value and rejects unsupported codes.
+        let values = [
+            (AssetClass::Other, 0),
+            (AssetClass::Equity, 1),
+            (AssetClass::Bond, 2),
+            (AssetClass::Cash, 3),
+            (AssetClass::Crypto, 4),
+            (AssetClass::Commodity, 5),
+        ];
+
+        for (asset_class, value) in values {
+            assert_eq!(i16::from(asset_class), value);
+            assert_eq!(AssetClass::try_from(value), Ok(asset_class));
+        }
+
+        assert!(AssetClass::try_from(6).is_err());
+    }
 }

--- a/dcapal-backend/crates/backend/tests/fixtures/portfolio.sql
+++ b/dcapal-backend/crates/backend/tests/fixtures/portfolio.sql
@@ -21,7 +21,7 @@ VALUES (
 );
 
 INSERT INTO portfolio_asset (
-    id, symbol, portfolio_id, name, asset_class, currency, provider,
+    id, symbol, portfolio_id, name, legacy_asset_class, currency, legacy_provider,
     quantity, target_weight, price, max_fee_impact, fee_type, fee_amount,
     fee_rate, min_fee, max_fee, average_buy_price, created_at, updated_at
 )

--- a/dcapal-backend/crates/backend/tests/migration_compatibility.rs
+++ b/dcapal-backend/crates/backend/tests/migration_compatibility.rs
@@ -3,13 +3,14 @@ use sqlx::PgPool;
 
 #[sqlx::test(migrations = false, fixtures("legacy_schema"))]
 async fn sqlx_migrations_adopt_the_existing_seaorm_schema(pool: PgPool) -> sqlx::Result<()> {
-    // The fixture represents a production database that was already migrated by SeaORM.
+    // GIVEN a production-shaped SeaORM database, WHEN SQLx applies its migrations,
+    // THEN the legacy text fields and the nullable canonical schema foundation coexist.
     MIGRATOR.run(&pool).await?;
 
     let migration_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM _sqlx_migrations")
         .fetch_one(&pool)
         .await?;
-    assert_eq!(migration_count, 4);
+    assert_eq!(migration_count, 5);
 
     let seaorm_table: Option<String> =
         sqlx::query_scalar("SELECT to_regclass('seaql_migrations')::text")
@@ -26,6 +27,39 @@ async fn sqlx_migrations_adopt_the_existing_seaorm_schema(pool: PgPool) -> sqlx:
     .fetch_one(&pool)
     .await?;
     assert_eq!(average_buy_price.as_deref(), Some("numeric"));
+
+    let columns: Vec<(String, String, String)> = sqlx::query_as(
+        "SELECT column_name, data_type, is_nullable
+         FROM information_schema.columns
+         WHERE table_name = 'portfolio_asset'
+           AND column_name IN (
+               'legacy_provider', 'legacy_asset_class', 'provider', 'asset_class',
+               'manual_price'
+           )
+         ORDER BY column_name",
+    )
+    .fetch_all(&pool)
+    .await?;
+    assert_eq!(
+        columns,
+        vec![
+            ("asset_class".into(), "smallint".into(), "YES".into()),
+            ("legacy_asset_class".into(), "text".into(), "NO".into()),
+            ("legacy_provider".into(), "text".into(), "NO".into()),
+            ("manual_price".into(), "numeric".into(), "YES".into()),
+            ("provider".into(), "smallint".into(), "YES".into()),
+        ]
+    );
+
+    let check_constraint_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*)
+         FROM pg_constraint
+         WHERE conrelid = 'portfolio_asset'::regclass
+           AND contype = 'c'",
+    )
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(check_constraint_count, 0);
 
     Ok(())
 }

--- a/dcapal-backend/migrations/20260813000000_portfolio_asset_schema_foundation.down.sql
+++ b/dcapal-backend/migrations/20260813000000_portfolio_asset_schema_foundation.down.sql
@@ -1,0 +1,10 @@
+ALTER TABLE portfolio_asset
+    DROP COLUMN IF EXISTS provider,
+    DROP COLUMN IF EXISTS asset_class,
+    DROP COLUMN IF EXISTS manual_price;
+
+ALTER TABLE portfolio_asset
+    RENAME COLUMN legacy_provider TO provider;
+
+ALTER TABLE portfolio_asset
+    RENAME COLUMN legacy_asset_class TO asset_class;

--- a/dcapal-backend/migrations/20260813000000_portfolio_asset_schema_foundation.up.sql
+++ b/dcapal-backend/migrations/20260813000000_portfolio_asset_schema_foundation.up.sql
@@ -1,0 +1,10 @@
+ALTER TABLE portfolio_asset
+    RENAME COLUMN provider TO legacy_provider;
+
+ALTER TABLE portfolio_asset
+    RENAME COLUMN asset_class TO legacy_asset_class;
+
+ALTER TABLE portfolio_asset
+    ADD COLUMN provider SMALLINT,
+    ADD COLUMN asset_class SMALLINT,
+    ADD COLUMN manual_price NUMERIC;

--- a/dcapal-backend/scripts/assert-smoke-data.sh
+++ b/dcapal-backend/scripts/assert-smoke-data.sh
@@ -80,9 +80,9 @@ assert_value \
     WHERE u.email = :'smoke_email'
       AND p.id = :'smoke_portfolio_id'::uuid
       AND a.symbol = 'vwce.mi'
-      AND a.asset_class = 'EQUITY'
+      AND a.legacy_asset_class = 'EQUITY'
       AND a.currency = 'usd'
-      AND a.provider = 'YF'
+      AND a.legacy_provider = 'YF'
       AND a.quantity = 1
       AND a.target_weight = 100
       AND a.price = 100

--- a/dcapal-backend/scripts/verify-postgres-upgrade.sh
+++ b/dcapal-backend/scripts/verify-postgres-upgrade.sh
@@ -115,9 +115,9 @@ INSERT INTO portfolio_asset (
     symbol,
     portfolio_id,
     name,
-    asset_class,
+    legacy_asset_class,
     currency,
-    provider,
+    legacy_provider,
     quantity,
     target_weight,
     price,
@@ -212,9 +212,9 @@ BEGIN
           AND p.id = '33333333-3333-4333-8333-333333333333'
           AND a.symbol = 'vwce.mi'
           AND a.name = 'Upgrade asset'
-          AND a.asset_class = 'EQUITY'
+          AND a.legacy_asset_class = 'EQUITY'
           AND a.currency = 'usd'
-          AND a.provider = 'YF'
+          AND a.legacy_provider = 'YF'
           AND a.quantity = 1
           AND a.target_weight = 100
           AND a.price = 100
@@ -223,7 +223,7 @@ BEGIN
         RAISE EXCEPTION 'restored portfolio asset is missing or changed';
     END IF;
 
-    IF (SELECT COUNT(*) FROM _sqlx_migrations) < 4
+    IF (SELECT COUNT(*) FROM _sqlx_migrations) < 5
        OR EXISTS (SELECT 1 FROM _sqlx_migrations WHERE success = FALSE) THEN
         RAISE EXCEPTION 'migration history is incomplete or contains a failed migration';
     END IF;


### PR DESCRIPTION
## Summary

Establish the canonical Portfolio Asset schema foundation while keeping the v1 Portfolio persistence contract deployable. The migration reserves integer-backed canonical Provider and Asset Class fields without normalizing or removing legacy text data.

## Related Issues

Closes #795

## Changes Made

- Add nullable `SMALLINT` `provider` and `asset_class` columns and nullable numeric `manual_price` to `portfolio_asset`.
- Preserve existing text values as `legacy_provider` and `legacy_asset_class`; update repository SQL, fixtures, and smoke scripts to use them.
- Add public `num_enum` Provider and Asset Class codes, plus conversion and migration-compatibility tests.

## Motivation

Portfolio Assets need a stable schema base before the follow-up normalization migration can safely deduplicate, map legacy data, and enforce the v2 identity model. This change provides that base without changing current v1 API behavior.

## Design decisions

The migration intentionally leaves canonical integer columns nullable and does not copy or normalize existing values. The follow-up migration owns data cleanup and conversion. It uses PostgreSQL `SMALLINT` columns rather than PostgreSQL enum types or check constraints, while `num_enum` defines the Rust mapping.

## Validation

- **Canonical enum mapping:** `GIVEN` each supported Provider and Asset Class code, `WHEN` it is converted to and from its primitive form, `THEN` its specified numeric value round-trips and unsupported values fail; covered by `cargo test -p dcapal-backend --lib --locked`.
- **Build compatibility:** `GIVEN` the updated migration and repository fixtures, `WHEN` the affected database test binaries compile, `THEN` both `migration_compatibility` and `portfolio_repository` build successfully with `--no-run`.
- **Formatting:** `GIVEN` the committed Rust sources, `WHEN` `cargo fmt --check` and `git diff --check` run, `THEN` they report no formatting or whitespace errors.

## Risk/Notes

- This is a forward schema bridge: production data remains in the legacy text fields until the follow-up normalization migration.
- Database-backed test execution was skipped because this environment's Docker daemon is unavailable. The integration test binaries compile successfully; run `make backend-db-up` and `make test-backend` in a Docker-enabled environment before merging.
