### PR TITLE
fix(migration): accept former asset migration state

### DIFF
--- a/dcapal-backend/crates/backend/tests/fixtures/legacy_schema.sql
+++ b/dcapal-backend/crates/backend/tests/fixtures/legacy_schema.sql
@@ -69,4 +69,5 @@ CREATE TABLE portfolio_asset_reference (
     portfolio_asset_id UUID NOT NULL,
     CONSTRAINT fk_portfolio_asset_reference_asset
         FOREIGN KEY (portfolio_asset_id) REFERENCES portfolio_asset (id)
+        ON UPDATE CASCADE
 );

--- a/dcapal-backend/crates/backend/tests/migration_compatibility.rs
+++ b/dcapal-backend/crates/backend/tests/migration_compatibility.rs
@@ -1,7 +1,9 @@
-use migration::MIGRATOR;
+use migration::{MIGRATOR, run_migrations};
 use rust_decimal::Decimal;
 use sqlx::PgPool;
 use uuid::Uuid;
+
+const FORMER_SHARED_ASSET_MIGRATION_CHECKSUM: &str = "37b5e148d245306df7d158e6e92ace259ba6c8030063df075b60ec10ac16d62317ff6ec123a56118b65e94b47826327d";
 
 #[sqlx::test(
     migrations = false,
@@ -221,8 +223,48 @@ async fn sqlx_migrations_adopt_the_existing_seaorm_schema(pool: PgPool) -> sqlx:
     fixtures("legacy_schema", "legacy_portfolio_assets")
 )]
 async fn failed_identity_migration_rolls_back_its_changes(pool: PgPool) -> sqlx::Result<()> {
-    // GIVEN an unexpected failure while rewriting IDs, WHEN the identity
-    // migration runs, THEN its ID and dependent-reference changes roll back.
+    // GIVEN the shared-asset migration has already completed, WHEN an
+    // unexpected failure occurs while the identity migration rewrites a
+    // non-v7 ID, THEN its ID and dependent-reference changes roll back.
+    MIGRATOR.run_to(20260826000000, &pool).await?;
+
+    let child_asset_id = Uuid::parse_str("40000000-0000-0000-0000-000000000001").unwrap();
+    let child_shared_id: Uuid = sqlx::query_scalar(
+        "INSERT INTO assets_data (
+             id, provider, symbol, name, currency, asset_class
+         )
+         VALUES (uuidv7(), 99, 'CHILD', 'Child Asset', 'EUR', 1)
+         RETURNING id",
+    )
+    .fetch_one(&pool)
+    .await?;
+    sqlx::query(
+        "INSERT INTO portfolio_asset (
+             id, portfolio_id, assets_data_id, quantity, target_weight,
+             average_buy_price, created_at, updated_at
+         )
+         SELECT $1, id, $2, 1, 0, NULL, NOW(), NOW()
+         FROM portfolios
+         LIMIT 1",
+    )
+    .bind(child_asset_id)
+    .bind(child_shared_id)
+    .execute(&pool)
+    .await?;
+    sqlx::query(
+        "CREATE TABLE child_identity_reference (
+             portfolio_asset_id UUID NOT NULL,
+             CONSTRAINT child_identity_reference_asset_fk
+                 FOREIGN KEY (portfolio_asset_id) REFERENCES portfolio_asset (id)
+         )",
+    )
+    .execute(&pool)
+    .await?;
+    sqlx::query("INSERT INTO child_identity_reference VALUES ($1)")
+        .bind(child_asset_id)
+        .execute(&pool)
+        .await?;
+
     sqlx::query(
         "CREATE FUNCTION reject_portfolio_asset_id_rewrite()
          RETURNS trigger AS $$
@@ -248,23 +290,17 @@ async fn failed_identity_migration_rolls_back_its_changes(pool: PgPool) -> sqlx:
         .await?;
     assert_eq!(migration_count, 7);
 
-    let foo_id: Uuid = sqlx::query_scalar(
-        "SELECT pa.id
-         FROM portfolio_asset AS pa
-         JOIN assets_data AS ad ON ad.id = pa.assets_data_id
-         WHERE ad.provider = 1 AND ad.symbol = 'FOO'",
-    )
-    .fetch_one(&pool)
-    .await?;
-    assert_eq!(
-        foo_id,
-        Uuid::parse_str("20000000-0000-0000-0000-000000000002").unwrap()
-    );
-    let reference_id: Uuid =
-        sqlx::query_scalar("SELECT portfolio_asset_id FROM portfolio_asset_reference")
+    let unchanged_child_id: Uuid =
+        sqlx::query_scalar("SELECT id FROM portfolio_asset WHERE id = $1")
+            .bind(child_asset_id)
             .fetch_one(&pool)
             .await?;
-    assert_eq!(reference_id, foo_id);
+    assert_eq!(unchanged_child_id, child_asset_id);
+    let reference_id: Uuid =
+        sqlx::query_scalar("SELECT portfolio_asset_id FROM child_identity_reference")
+            .fetch_one(&pool)
+            .await?;
+    assert_eq!(reference_id, child_asset_id);
 
     let child_migration_applied: bool = sqlx::query_scalar(
         "SELECT EXISTS (
@@ -274,6 +310,160 @@ async fn failed_identity_migration_rolls_back_its_changes(pool: PgPool) -> sqlx:
     .fetch_one(&pool)
     .await?;
     assert!(!child_migration_applied);
+
+    Ok(())
+}
+
+#[sqlx::test(
+    migrations = false,
+    fixtures("legacy_schema", "legacy_portfolio_assets")
+)]
+async fn identity_migration_rewires_dependent_foreign_keys(pool: PgPool) -> sqlx::Result<()> {
+    // GIVEN the shared-asset migration has completed and a later row still
+    // has a non-v7 ID, WHEN the identity migration runs, THEN it rewrites the
+    // row and its dependent foreign-key reference together.
+    MIGRATOR.run_to(20260826000000, &pool).await?;
+
+    let old_asset_id = Uuid::parse_str("40000000-0000-0000-0000-000000000002").unwrap();
+    let shared_asset_id: Uuid = sqlx::query_scalar(
+        "INSERT INTO assets_data (
+             id, provider, symbol, name, currency, asset_class
+         )
+         VALUES (uuidv7(), 99, 'CHILD_SUCCESS', 'Child Success', 'EUR', 1)
+         RETURNING id",
+    )
+    .fetch_one(&pool)
+    .await?;
+    sqlx::query(
+        "INSERT INTO portfolio_asset (
+             id, portfolio_id, assets_data_id, quantity, target_weight,
+             average_buy_price, created_at, updated_at
+         )
+         SELECT $1, id, $2, 1, 0, NULL, NOW(), NOW()
+         FROM portfolios
+         LIMIT 1",
+    )
+    .bind(old_asset_id)
+    .bind(shared_asset_id)
+    .execute(&pool)
+    .await?;
+    sqlx::query(
+        "CREATE TABLE child_identity_reference_success (
+             portfolio_asset_id UUID NOT NULL,
+             CONSTRAINT child_identity_reference_success_asset_fk
+                 FOREIGN KEY (portfolio_asset_id) REFERENCES portfolio_asset (id)
+         )",
+    )
+    .execute(&pool)
+    .await?;
+    sqlx::query("INSERT INTO child_identity_reference_success VALUES ($1)")
+        .bind(old_asset_id)
+        .execute(&pool)
+        .await?;
+
+    MIGRATOR.run(&pool).await?;
+
+    let rewritten_asset_id: Uuid =
+        sqlx::query_scalar("SELECT portfolio_asset_id FROM child_identity_reference_success")
+            .fetch_one(&pool)
+            .await?;
+    assert_ne!(rewritten_asset_id, old_asset_id);
+    assert_eq!(rewritten_asset_id.get_version_num(), 7);
+    let stored_asset_id: Uuid = sqlx::query_scalar("SELECT id FROM portfolio_asset WHERE id = $1")
+        .bind(rewritten_asset_id)
+        .fetch_one(&pool)
+        .await?;
+    assert_eq!(stored_asset_id, rewritten_asset_id);
+
+    Ok(())
+}
+
+#[sqlx::test(
+    migrations = false,
+    fixtures("legacy_schema", "legacy_portfolio_assets")
+)]
+async fn migration_runner_accepts_the_former_shared_asset_checksum(
+    pool: PgPool,
+) -> sqlx::Result<()> {
+    // GIVEN a database in the former migration's completed state, including
+    // rewritten IDs and its uniqueness/default settings, WHEN the migration
+    // runner starts, THEN it accepts only that known checksum and proceeds
+    // without rewriting those already-v7 IDs.
+    MIGRATOR.run_to(20260826000000, &pool).await?;
+    sqlx::query("UPDATE portfolio_asset SET id = uuidv7()")
+        .execute(&pool)
+        .await?;
+    sqlx::query(
+        "ALTER TABLE portfolio_asset
+         ALTER COLUMN id SET DEFAULT uuidv7(),
+         ADD CONSTRAINT portfolio_asset_portfolio_assets_data_key
+             UNIQUE (portfolio_id, assets_data_id)",
+    )
+    .execute(&pool)
+    .await?;
+    let ids_before: Vec<Uuid> = sqlx::query_scalar("SELECT id FROM portfolio_asset ORDER BY id")
+        .fetch_all(&pool)
+        .await?;
+    sqlx::query(
+        "UPDATE _sqlx_migrations
+         SET checksum = decode($1, 'hex')
+         WHERE version = 20260826000000",
+    )
+    .bind(FORMER_SHARED_ASSET_MIGRATION_CHECKSUM)
+    .execute(&pool)
+    .await?;
+
+    run_migrations(&pool, None).await.unwrap();
+
+    let child_migration_applied: bool = sqlx::query_scalar(
+        "SELECT success
+         FROM _sqlx_migrations
+         WHERE version = 20260827000000",
+    )
+    .fetch_one(&pool)
+    .await?;
+    assert!(child_migration_applied);
+
+    let ids_after: Vec<Uuid> = sqlx::query_scalar("SELECT id FROM portfolio_asset ORDER BY id")
+        .fetch_all(&pool)
+        .await?;
+    assert_eq!(ids_after, ids_before);
+
+    let recorded_checksum: String = sqlx::query_scalar(
+        "SELECT encode(checksum, 'hex')
+         FROM _sqlx_migrations
+         WHERE version = 20260826000000",
+    )
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(recorded_checksum, FORMER_SHARED_ASSET_MIGRATION_CHECKSUM);
+
+    Ok(())
+}
+
+#[sqlx::test(
+    migrations = false,
+    fixtures("legacy_schema", "legacy_portfolio_assets")
+)]
+async fn migration_runner_rejects_an_unexpected_checksum(pool: PgPool) -> sqlx::Result<()> {
+    // GIVEN a database with an unknown checksum for a recorded migration,
+    // WHEN the migration runner starts, THEN it preserves SQLx's mismatch
+    // error instead of treating the change as a compatibility case.
+    MIGRATOR.run_to(20260826000000, &pool).await?;
+    sqlx::query(
+        "UPDATE _sqlx_migrations
+         SET checksum = decode(repeat('00', 48), 'hex')
+         WHERE version = 20260826000000",
+    )
+    .execute(&pool)
+    .await?;
+
+    let error = run_migrations(&pool, None).await.unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("migration 20260826000000 was previously applied but has been modified")
+    );
 
     Ok(())
 }

--- a/dcapal-backend/crates/migration/src/lib.rs
+++ b/dcapal-backend/crates/migration/src/lib.rs
@@ -1,2 +1,105 @@
+use std::borrow::Cow;
+
+use sqlx::PgPool;
+use sqlx::migrate::{MigrateError, Migration, Migrator};
+
 /// The embedded SQLx migrations for the backend database.
 pub static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("../../migrations");
+
+const SHARED_ASSET_MIGRATION_VERSION: i64 = 20260826000000;
+const FORMER_SHARED_ASSET_MIGRATION_CHECKSUM: [u8; 48] = [
+    0x37, 0xb5, 0xe1, 0x48, 0xd2, 0x45, 0x30, 0x6d, 0xf7, 0xd1, 0x58, 0xe6, 0xe9, 0x2a, 0xce, 0x25,
+    0x9b, 0xa6, 0xc8, 0x03, 0x00, 0x63, 0xdf, 0x07, 0x5b, 0x60, 0xec, 0x10, 0xac, 0x16, 0xd6, 0x23,
+    0x17, 0xff, 0x6e, 0xc1, 0x23, 0xa5, 0x61, 0x18, 0xb6, 0x5e, 0x94, 0xb4, 0x78, 0x26, 0x32, 0x7d,
+];
+
+/// Runs migrations while accepting the former shared-asset migration checksum.
+///
+/// The shared-asset migration was deployed once with an implementation that
+/// also rewrote Portfolio Asset IDs. Its replacement keeps that migration's
+/// current production behavior in source control and moves the identity work
+/// to the following migration. Existing databases with the former checksum
+/// must still reach that following migration without weakening SQLx's normal
+/// checksum validation for any other change.
+pub async fn run_migrations(pool: &PgPool, target_version: Option<i64>) -> anyhow::Result<()> {
+    if former_checksum_is_recorded(pool).await? {
+        let compatible_migrator = migrator_with_former_checksum();
+        return run_migrator(&compatible_migrator, pool, target_version)
+            .await
+            .map_err(Into::into);
+    }
+
+    match run_migrator(&MIGRATOR, pool, target_version).await {
+        Err(MigrateError::VersionMismatch(version))
+            if version == SHARED_ASSET_MIGRATION_VERSION
+                && former_checksum_is_recorded(pool).await? =>
+        {
+            let compatible_migrator = migrator_with_former_checksum();
+            run_migrator(&compatible_migrator, pool, target_version)
+                .await
+                .map_err(Into::into)
+        }
+        result => result.map_err(Into::into),
+    }
+}
+
+async fn run_migrator(
+    migrator: &Migrator,
+    pool: &PgPool,
+    target_version: Option<i64>,
+) -> Result<(), MigrateError> {
+    let mut connection = pool.acquire().await.map_err(MigrateError::Execute)?;
+    let result = migrator
+        .run_direct(target_version, &mut *connection, false)
+        .await;
+    if result.is_err() {
+        // SQLx holds its session advisory lock when run_direct returns an
+        // error. Close the connection so a compatibility retry cannot inherit
+        // that lock from the pool.
+        let _ = connection.close().await;
+    }
+
+    result
+}
+
+async fn former_checksum_is_recorded(pool: &PgPool) -> sqlx::Result<bool> {
+    let migrations_table_exists: bool =
+        sqlx::query_scalar("SELECT to_regclass('_sqlx_migrations') IS NOT NULL")
+            .fetch_one(pool)
+            .await?;
+    if !migrations_table_exists {
+        return Ok(false);
+    }
+
+    let checksum: Option<Vec<u8>> =
+        sqlx::query_scalar("SELECT checksum FROM _sqlx_migrations WHERE version = $1 AND success")
+            .bind(SHARED_ASSET_MIGRATION_VERSION)
+            .fetch_optional(pool)
+            .await?;
+
+    Ok(checksum.as_deref() == Some(FORMER_SHARED_ASSET_MIGRATION_CHECKSUM.as_slice()))
+}
+
+fn migrator_with_former_checksum() -> Migrator {
+    let migrations = MIGRATOR
+        .iter()
+        .cloned()
+        .map(|mut migration| {
+            if migration.version == SHARED_ASSET_MIGRATION_VERSION
+                && migration.migration_type.is_up_migration()
+            {
+                migration.checksum = Cow::Owned(FORMER_SHARED_ASSET_MIGRATION_CHECKSUM.to_vec());
+            }
+            migration
+        })
+        .collect::<Vec<Migration>>();
+
+    Migrator {
+        migrations: Cow::Owned(migrations),
+        ignore_missing: MIGRATOR.ignore_missing,
+        locking: MIGRATOR.locking,
+        no_tx: MIGRATOR.no_tx,
+        table_name: MIGRATOR.table_name.clone(),
+        create_schemas: MIGRATOR.create_schemas.clone(),
+    }
+}

--- a/dcapal-backend/crates/migration/src/main.rs
+++ b/dcapal-backend/crates/migration/src/main.rs
@@ -1,7 +1,7 @@
 use std::env;
 
 use anyhow::{Context, Result, bail};
-use migration::MIGRATOR;
+use migration::run_migrations;
 use sqlx::postgres::PgPoolOptions;
 
 #[tokio::main]
@@ -12,11 +12,7 @@ async fn main() -> Result<()> {
         .await
         .with_context(|| format!("failed to connect to PostgreSQL at {database_url}"))?;
 
-    if let Some(target_version) = target_version {
-        MIGRATOR.run_to(target_version, &pool).await?;
-    } else {
-        MIGRATOR.run(&pool).await?;
-    }
+    run_migrations(&pool, target_version).await?;
     pool.close().await;
 
     Ok(())

--- a/dcapal-backend/migrations/20260827000000_seal_portfolio_asset_identity.up.sql
+++ b/dcapal-backend/migrations/20260827000000_seal_portfolio_asset_identity.up.sql
@@ -1,5 +1,6 @@
--- Rewrite existing Portfolio Asset identifiers after the shared-asset
--- migration has removed duplicate relationships.
+-- Rewrite any existing Portfolio Asset identifiers that the shared-asset
+-- migration did not already rewrite. This keeps the migration compatible with
+-- databases where 20260826000000 was applied before this migration existed.
 CREATE TEMP TABLE portfolio_asset_id_map (
     old_id UUID PRIMARY KEY,
     new_id UUID NOT NULL UNIQUE
@@ -7,7 +8,8 @@ CREATE TEMP TABLE portfolio_asset_id_map (
 
 INSERT INTO portfolio_asset_id_map (old_id, new_id)
 SELECT id, uuidv7()
-FROM portfolio_asset;
+FROM portfolio_asset
+WHERE SUBSTRING(id::text FROM 15 FOR 1) <> '7';
 
 CREATE TEMP TABLE portfolio_asset_fk_definitions (
     child_schema NAME NOT NULL,


### PR DESCRIPTION
## Summary

Make the migration runner compatible with Beta databases that recorded the former shared-asset migration checksum, while preserving SQLx mismatch protection for every other checksum. The child identity migration now leaves already-rewritten UUIDv7 IDs unchanged.

## Related Issues

None.

## Changes Made

- Accept the known former SHA-384 checksum for migration `20260826000000`.
- Retry safely if another migration runner applies the former version while the current runner waits for the advisory lock.
- Close failed migration connections before retrying, preventing a leaked session advisory lock.
- Skip UUIDv7 Portfolio Asset IDs in migration `20260827000000` while retaining dependent-FK rewiring for legacy IDs.
- Extend migration tests for former-schema state, rollback, dependent references, and unexpected checksums.

## Motivation

Prod recorded the current `20260826000000` checksum, while Beta recorded the former implementation. SQLx correctly rejects the byte-level difference and the startup loop never reaches the next migration. The compatibility path lets both deployed states converge without editing database history manually.

## Design decisions

The former checksum is accepted only for this one migration and only when it is the recorded successful checksum. The current migration source remains unchanged, and unknown checksum changes still return SQLx's normal version-mismatch error. Existing IDs are rewritten only when their UUID version is not 7; future IDs remain application-generated.

## Validation

- **Former migration state:** `GIVEN` already-v7 IDs, the former uniqueness constraint, and the former checksum, `WHEN` the runner executes, `THEN` the child migration succeeds without changing those IDs.
- **Current migration state:** `GIVEN` legacy IDs and the current checksum, `WHEN` the full migration set executes, `THEN` IDs are rewritten, dependent references follow them, and uniqueness is sealed.
- **Unexpected change:** `GIVEN` an unknown checksum, `WHEN` the runner starts, `THEN` SQLx reports a version mismatch.
