### PR TITLE
ci: pin deployments to immutable image revisions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,11 +29,14 @@ env:
 jobs:
   validate-inputs:
     runs-on: ubuntu-slim
+    outputs:
+      resolved_image_tag: ${{ steps.validate.outputs.resolved_image_tag }}
     env:
       DEPLOY_ENVIRONMENT: ${{ inputs.deploy_environment }}
       IMAGE_TAG: ${{ inputs.image_tag }}
     steps:
-      - run: |
+      - id: validate
+        run: |
           set -euo pipefail
           case "${DEPLOY_ENVIRONMENT}" in
             development|production) ;;
@@ -43,6 +46,28 @@ jobs:
             echo "Image tag is not a valid Docker tag" >&2
             exit 1
           }
+
+          resolved_image_tag="${IMAGE_TAG}"
+          if [[ "${IMAGE_TAG}" == "master" ]]; then
+            image_json="$(docker buildx imagetools inspect "${DOCKER_REPO}:master" --format '{{json .Image}}')" || {
+              echo "Could not inspect the master image" >&2
+              exit 1
+            }
+            resolved_image_tag="$(jq -r '((.config // .["linux/amd64"].config).Labels // {})["org.opencontainers.image.revision"] // empty' <<< "${image_json}")" || {
+              echo "Could not parse the master image revision label" >&2
+              exit 1
+            }
+            if [[ ! "${resolved_image_tag}" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "Master image revision is not a valid lowercase 40-character SHA" >&2
+              exit 1
+            fi
+            docker buildx imagetools inspect "${DOCKER_REPO}:${resolved_image_tag}" >/dev/null || {
+              echo "The master image revision tag does not exist: ${resolved_image_tag}" >&2
+              exit 1
+            }
+          fi
+
+          echo "resolved_image_tag=${resolved_image_tag}" >> "${GITHUB_OUTPUT}"
 
   optimizer-build:
     runs-on: ubuntu-latest
@@ -120,7 +145,7 @@ jobs:
       cancel-in-progress: false
       queue: max
     runs-on: ubuntu-slim
-    needs: frontend-build
+    needs: [validate-inputs, frontend-build]
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
@@ -247,7 +272,7 @@ jobs:
           version: "3.9"
           services:
             dcapal:
-              image: ${{ env.DOCKER_REPO }}:${{ inputs.image_tag }}
+              image: ${{ env.DOCKER_REPO }}:${{ needs.validate-inputs.outputs.resolved_image_tag }}
               env_file: dcapal.env
               restart: always
               ports:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -108,6 +108,8 @@ jobs:
           tags: |
             type=raw,value=${{ needs.resolve-image.outputs.ref_tag }}
             type=raw,value=${{ needs.resolve-image.outputs.image_tag }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
       - name: Set up Docker Buildx
         id: setup-buildx
         uses: docker/setup-buildx-action@v4


### PR DESCRIPTION
## Summary

Resolve `master` deployments to the immutable image revision tag stored in the image metadata, and publish that revision label during image builds.

## Related Issues

None

## Changes Made

- Add the `org.opencontainers.image.revision` label to published Docker images.
- Validate and expose the resolved image tag from the input-validation job.
- Use the resolved tag when starting the deployed service in deployment checks.
- Verify that the referenced revision tag exists before deployment proceeds.

## Motivation

Deploying directly from the mutable `master` image tag can cause validation and deployment checks to use different image contents. Resolving the tag to the image’s commit SHA makes the deployed artifact reproducible.

## Design decisions

- Preserve explicit image tags unchanged.
- Resolve only `master` to a validated lowercase 40-character commit SHA.
- Fail early when image metadata is unavailable, malformed, or the immutable tag does not exist.

## Testing

Not run (not requested).