### PR TITLE
fix(metrics): reduce visitor metric cardinality

### DIFF
--- a/dcapal-backend/crates/backend/src/app/infra/stats.rs
+++ b/dcapal-backend/crates/backend/src/app/infra/stats.rs
@@ -4,6 +4,7 @@ use std::{
     time::Instant,
 };
 
+use crate::{AppContext, error::Result, ports::outbound::repository::StatsRepository};
 use axum::{
     extract::{ConnectInfo, Request, State},
     middleware::Next,
@@ -11,16 +12,13 @@ use axum::{
 };
 use hyper::HeaderMap;
 use metrics::{counter, histogram};
-use tracing::{info, log::error};
-
-use crate::{
-    AppContext, app::services::ip2location::Ip2LocationService, error::Result,
-    ports::outbound::repository::StatsRepository,
-};
 
 const BASE: &str = "dcapal";
 
+/// Total number of visits recorded from non-loopback IP addresses.
 pub const VISITORS_TOTAL: &str = concatcp!(BASE, '_', "visitors_total");
+/// Total number of distinct IP addresses recorded as visitors.
+pub const UNIQUE_VISITORS_TOTAL: &str = concatcp!(BASE, '_', "unique_visitors_total");
 pub const REQUESTS_TOTAL: &str = concatcp!(BASE, '_', "requests_total");
 pub const LATENCY_SUMMARY: &str = concatcp!(BASE, '_', "latency_summary");
 pub const IMPORTED_PORTFOLIOS_TOTAL: &str = concatcp!(BASE, '_', "imported_portfolios_total");
@@ -55,13 +53,7 @@ pub async fn requests_stats(
     counter!(REQUESTS_TOTAL, &[("path", path)]).increment(1);
 
     // Visitors stats
-    record_visitors_stats(
-        req.headers(),
-        addr,
-        state.repos.stats.clone(),
-        state.services.ip2location.clone(),
-    )
-    .await?;
+    record_visitors_stats(req.headers(), addr, state.repos.stats.clone()).await?;
 
     Ok(next.run(req).await)
 }
@@ -70,7 +62,6 @@ async fn record_visitors_stats(
     headers: &HeaderMap,
     addr: SocketAddr,
     repo: Arc<StatsRepository>,
-    ip_service: Option<Arc<Ip2LocationService>>,
 ) -> Result<()> {
     static IP_HEADERS: [&str; 2] = ["CF-Connecting-IP", "X-Real-IP"];
     static FALLBACK_IP: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
@@ -91,65 +82,10 @@ async fn record_visitors_stats(
     }
 
     let ip_str = ip.to_string();
-    repo.bump_visit(&ip_str).await?;
-
-    let Some(ip_service) = ip_service else {
-        return Ok(());
-    };
-
-    tokio::spawn(async move { fetch_geo_ip(ip, repo, ip_service).await });
-
-    Ok(())
-}
-
-#[allow(dead_code)]
-async fn fetch_geo_ip(ip: IpAddr, repo: Arc<StatsRepository>, ip_service: Arc<Ip2LocationService>) {
-    if let Err(e) = fetch_geo_ip_inner(ip, repo, ip_service).await {
-        error!("Error occurred in fetching GeoIP for {ip}: {e:?}");
-    }
-}
-
-async fn fetch_geo_ip_inner(
-    ip: IpAddr,
-    repo: Arc<StatsRepository>,
-    ip_service: Arc<Ip2LocationService>,
-) -> Result<()> {
-    if ip.is_loopback() {
-        return Ok(());
-    }
-
-    let ip_str = ip.to_string();
-    if let Some(geo) = repo.find_visitor_ip(&ip_str).await? {
-        counter!(
-            VISITORS_TOTAL,
-            &[
-                ("ip", geo.ip),
-                ("latitude", geo.latitude),
-                ("longitude", geo.longitude),
-            ]
-        )
-        .increment(1);
-        return Ok(());
-    }
-
-    let Some(geo) = ip_service.lookup(ip) else {
-        error!("Visitor IP not found ({ip})");
-        return Ok(());
-    };
-
-    counter!(
-        VISITORS_TOTAL,
-        &[
-            ("ip", geo.ip.clone()),
-            ("latitude", geo.latitude.clone()),
-            ("longitude", geo.longitude.clone()),
-        ]
-    )
-    .increment(1);
-
-    let is_stored = repo.store_visitor_ip(&ip_str, &geo).await?;
-    if !is_stored {
-        info!("Visitor ip ({ip}) already exists");
+    let visit_count = repo.bump_visit(&ip_str).await?;
+    counter!(VISITORS_TOTAL).increment(1);
+    if visit_count == 1 {
+        counter!(UNIQUE_VISITORS_TOTAL).increment(1);
     }
 
     Ok(())

--- a/dcapal-backend/crates/backend/src/lib.rs
+++ b/dcapal-backend/crates/backend/src/lib.rs
@@ -24,10 +24,7 @@ use tracing::{error, info};
 use crate::{
     app::{
         infra,
-        services::{
-            ip2location::Ip2LocationService, market_data::MarketDataService,
-            portfolio::PortfolioService,
-        },
+        services::{market_data::MarketDataService, portfolio::PortfolioService},
         workers::{market_discovery::MarketDiscoveryWorker, price_updater::PriceUpdaterWorker},
     },
     config::{Config, Postgres},
@@ -82,7 +79,6 @@ pub type AppContext = Arc<AppContextInner>;
 #[derive(Clone)]
 struct Services {
     mkt_data: Arc<MarketDataService>,
-    ip2location: Option<Arc<Ip2LocationService>>,
     portfolio: Arc<PortfolioService>,
 }
 
@@ -151,21 +147,8 @@ impl DcaServer {
             ipapi: Arc::new(IpApi::new(http.clone(), &config.app.providers)),
         });
 
-        let ip2location = {
-            if let Some(ref service_config) = config.app.services {
-                if let Some(ref ip_config) = service_config.ip {
-                    Some(Arc::new(Ip2LocationService::try_new(&ip_config.db_path)?))
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        };
-
         let services = Services {
             mkt_data: Arc::new(MarketDataService::new(repos.mkt_data.clone())),
-            ip2location,
             portfolio: Arc::new(PortfolioService::new(repos.portfolio.clone())),
         };
 
@@ -266,7 +249,12 @@ impl DcaServer {
         describe_counter!(
             infra::stats::VISITORS_TOTAL,
             Unit::Count,
-            "Number of API visitors"
+            "Number of visits from real IP addresses"
+        );
+        describe_counter!(
+            infra::stats::UNIQUE_VISITORS_TOTAL,
+            Unit::Count,
+            "Number of unique visitors from real IP addresses"
         );
         describe_counter!(
             infra::stats::REQUESTS_TOTAL,
@@ -285,11 +273,8 @@ impl DcaServer {
         );
 
         // Refresh Prometheus stats
-        if let Err(e) = refresh_total_visitors_stats(&self.ctx.repos.stats).await {
-            error!(
-                "Failed to refresh Prometheus {} metric: {e:?}",
-                infra::stats::VISITORS_TOTAL
-            );
+        if let Err(e) = refresh_visitors_stats(&self.ctx.repos.stats).await {
+            error!("Failed to refresh Prometheus visitor metrics: {e:?}");
         }
         if let Err(e) = refresh_imported_portfolios_stats(&self.ctx.repos.stats).await {
             error!(
@@ -349,23 +334,22 @@ async fn build_postgres_pool(config: &Postgres) -> Result<PgPool> {
     Ok(pool)
 }
 
-async fn refresh_total_visitors_stats(stats_repo: &StatsRepository) -> Result<()> {
+/// Restores aggregate visitor counters from the persisted per-IP visit hash.
+async fn refresh_visitors_stats(stats_repo: &StatsRepository) -> Result<()> {
     let visitors = stats_repo.fetch_all_visitors().await?;
-    for (ip, count) in visitors {
-        // Refresh Prometheus visitors location
-        let geo = stats_repo.find_visitor_ip(&ip).await?;
-        if let Some(geo) = geo {
-            counter!(
-                infra::stats::VISITORS_TOTAL,
-                &[
-                    ("ip", geo.ip),
-                    ("latitude", geo.latitude),
-                    ("longitude", geo.longitude),
-                ]
-            )
-            .increment(count as u64);
-        }
-    }
+    let (total_visits, unique_visitors) = visitors.values().fold(
+        (0_u64, 0_u64),
+        |(total_visits, unique_visitors), &visit_count| {
+            if visit_count > 0 {
+                (total_visits + visit_count as u64, unique_visitors + 1)
+            } else {
+                (total_visits, unique_visitors)
+            }
+        },
+    );
+
+    counter!(infra::stats::VISITORS_TOTAL).increment(total_visits);
+    counter!(infra::stats::UNIQUE_VISITORS_TOTAL).increment(unique_visitors);
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Reduce Grafana metric cardinality by replacing per-IP and geolocation labels with aggregate visitor counters.

## Related Issues

None

## Changes Made

- Track total visits and unique visitors using label-free counters.
- Restore both counters from persisted per-IP visit counts during startup.
- Remove the GeoIP lookup service and related visitor geolocation metric logic.

## Motivation

Per-IP and location labels create high-cardinality Prometheus metrics, increasing storage and query costs. Aggregate counters preserve visitor totals while keeping metric cardinality bounded.

## Design decisions

- Retain per-IP visit counts in the repository to calculate unique visitors and restore metrics after restart.
- Count a visitor as unique when their persisted visit count reaches one.
- Remove GeoIP initialization because geolocation is no longer needed for metrics.

## Testing

Not run (not requested)