### PR TITLE
fix(frontend): improve interactive controls and portfolio UI feedback

### DIFF
--- a/dcapal-frontend/src/components/allocationFlow/steps/portfolio/assetCard.js
+++ b/dcapal-frontend/src/components/allocationFlow/steps/portfolio/assetCard.js
@@ -264,9 +264,10 @@ export const AssetCard = ({
         </div>
       )}
       <div className="w-full mt-4 flex flex-col gap-3">
-        <div
+        <button
+          type="button"
           data-testid="transaction-fees"
-          className="flex gap-1 items-center font-light text-xs"
+          className="inline-flex self-start appearance-none border-0 bg-transparent p-0 text-left gap-1 items-center font-light text-xs cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
           {...getToggleProps()}
         >
           <span
@@ -277,7 +278,7 @@ export const AssetCard = ({
             {">"}
           </span>
           <span>{t("assetCard.transactionFees")}</span>
-        </div>
+        </button>
         <div
           className="w-full flex flex-col gap-1 justify-start text-sm"
           {...getCollapseProps()}

--- a/dcapal-frontend/src/components/allocationFlow/steps/portfolio/searchBar.tsx
+++ b/dcapal-frontend/src/components/allocationFlow/steps/portfolio/searchBar.tsx
@@ -14,6 +14,7 @@ import { useTranslation } from "react-i18next";
 import { Provider, useYahooPrice } from "@/api/priceProviders";
 import { useAppStore } from "@/state/appStore";
 import { useCurrentPortfolio } from "@/state/portfolioStore";
+import { Input } from "@/components/ui/input";
 import {
   PRICE_STALE_TIME,
   SEARCH_STALE_TIME,
@@ -207,9 +208,9 @@ export const SearchBar = (props: SearchBarProps) => {
 
   return (
     <div className="relative flex flex-col items-center justify-center">
-      <input
+      <Input
         data-testid="portfolio-search"
-        className="w-full h-12 px-6 pb-px border-2 rounded-3xl border-neutral-500/40 focus:border-neutral-500 focus-visible:outline-none uppercase placeholder:normal-case z-20"
+        className="w-full h-12 px-6 py-0 border-2 rounded-3xl bg-background border-neutral-500/40 text-base md:text-base focus:border-neutral-500 focus-visible:outline-none uppercase placeholder:normal-case z-20"
         value={props.text}
         placeholder={t("searchBar.placeholder")}
         onChange={handleAddAssetInputChange}

--- a/dcapal-frontend/src/components/core/helpIcon.js
+++ b/dcapal-frontend/src/components/core/helpIcon.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import {
   Tooltip,
   TooltipContent,
@@ -14,22 +14,28 @@ import {
   DrawerTrigger,
 } from "@/components/ui/drawer";
 
-const HelpIcon = () => (
-  <span className="inline-flex items-center justify-center w-4 h-4 rounded-full bg-neutral-200 text-neutral-600 text-[10px] cursor-help">
-    ?
-  </span>
-);
+const HelpIcon = React.forwardRef(({ title, ...props }, ref) => (
+  <button
+    ref={ref}
+    type="button"
+    aria-label={title}
+    className="inline-flex appearance-none items-center justify-center w-4 h-4 p-0 border-0 rounded-full bg-neutral-200 text-neutral-600 text-[10px] cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+    {...props}
+  >
+    <span aria-hidden="true">?</span>
+  </button>
+));
+HelpIcon.displayName = "HelpIcon";
 
 export const ResponsiveHelpIcon = ({ title, tooltip, isMobile }) => {
   const [open, setOpen] = useState(false);
+  const clickShouldOpen = useRef(false);
 
   if (isMobile) {
     return (
       <Drawer open={open} onOpenChange={setOpen}>
         <DrawerTrigger asChild>
-          <button type="button">
-            <HelpIcon />
-          </button>
+          <HelpIcon title={title} />
         </DrawerTrigger>
         <DrawerContent>
           <DrawerHeader>
@@ -43,11 +49,28 @@ export const ResponsiveHelpIcon = ({ title, tooltip, isMobile }) => {
 
   return (
     <TooltipProvider>
-      <Tooltip>
+      <Tooltip open={open} onOpenChange={setOpen}>
         <TooltipTrigger asChild>
-          <span>
-            <HelpIcon />
-          </span>
+          <HelpIcon
+            title={title}
+            aria-expanded={open}
+            onPointerDown={(event) => {
+              clickShouldOpen.current = !open;
+              if (open) {
+                // Prevent Radix from handling this pointer down so the
+                // controlled tooltip closes exactly once on repeated clicks.
+                event.preventDefault();
+                setOpen(false);
+              }
+            }}
+            onClick={(event) => {
+              event.preventDefault();
+              const shouldOpen =
+                event.detail === 0 ? !open : clickShouldOpen.current;
+              clickShouldOpen.current = false;
+              setOpen(shouldOpen);
+            }}
+          />
         </TooltipTrigger>
         <TooltipContent className="max-w-[16rem]">
           <p>{tooltip}</p>

--- a/dcapal-frontend/src/components/ui/button.jsx
+++ b/dcapal-frontend/src/components/ui/button.jsx
@@ -5,7 +5,7 @@ import { cva } from "class-variance-authority";
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-md ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex cursor-pointer items-center justify-center gap-2 whitespace-nowrap rounded-md text-md ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {

--- a/dcapal-frontend/src/components/ui/dialog.jsx
+++ b/dcapal-frontend/src/components/ui/dialog.jsx
@@ -1,16 +1,16 @@
-import * as React from "react"
-import * as DialogPrimitive from "@radix-ui/react-dialog"
-import { X } from "lucide-react"
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-const Dialog = DialogPrimitive.Root
+const Dialog = DialogPrimitive.Root;
 
-const DialogTrigger = DialogPrimitive.Trigger
+const DialogTrigger = DialogPrimitive.Trigger;
 
-const DialogPortal = DialogPrimitive.Portal
+const DialogPortal = DialogPrimitive.Portal;
 
-const DialogClose = DialogPrimitive.Close
+const DialogClose = DialogPrimitive.Close;
 
 const DialogOverlay = React.forwardRef(({ className, ...props }, ref) => (
   <DialogPrimitive.Overlay
@@ -19,66 +19,76 @@ const DialogOverlay = React.forwardRef(({ className, ...props }, ref) => (
       "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
-    {...props} />
-))
-DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
-const DialogContent = React.forwardRef(({ className, children, ...props }, ref) => (
-  <DialogPortal>
-    <DialogOverlay />
-    <DialogPrimitive.Content
-      ref={ref}
-      className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-[95%] max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] rounded-md sm:rounded-lg",
-        className
-      )}
-      {...props}>
-      {children}
-      <DialogPrimitive.Close
-        className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </DialogPrimitive.Close>
-    </DialogPrimitive.Content>
-  </DialogPortal>
-))
-DialogContent.displayName = DialogPrimitive.Content.displayName
+const DialogContent = React.forwardRef(
+  ({ className, children, ...props }, ref) => (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        ref={ref}
+        className={cn(
+          "fixed left-[50%] top-[50%] z-50 grid w-[95%] max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] rounded-md sm:rounded-lg",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <DialogPrimitive.Close className="absolute right-4 top-4 cursor-pointer rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:cursor-not-allowed data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+);
+DialogContent.displayName = DialogPrimitive.Content.displayName;
 
-const DialogHeader = ({
-  className,
-  ...props
-}) => (
+const DialogHeader = ({ className, ...props }) => (
   <div
-    className={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)}
-    {...props} />
-)
-DialogHeader.displayName = "DialogHeader"
+    className={cn(
+      "flex flex-col space-y-1.5 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+);
+DialogHeader.displayName = "DialogHeader";
 
-const DialogFooter = ({
-  className,
-  ...props
-}) => (
+const DialogFooter = ({ className, ...props }) => (
   <div
-    className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)}
-    {...props} />
-)
-DialogFooter.displayName = "DialogFooter"
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+);
+DialogFooter.displayName = "DialogFooter";
 
 const DialogTitle = React.forwardRef(({ className, ...props }, ref) => (
   <DialogPrimitive.Title
     ref={ref}
-    className={cn("text-lg font-semibold leading-none tracking-tight", className)}
-    {...props} />
-))
-DialogTitle.displayName = DialogPrimitive.Title.displayName
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
 
 const DialogDescription = React.forwardRef(({ className, ...props }, ref) => (
   <DialogPrimitive.Description
     ref={ref}
     className={cn("text-sm text-muted-foreground", className)}
-    {...props} />
-))
-DialogDescription.displayName = DialogPrimitive.Description.displayName
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
 
 export {
   Dialog,
@@ -91,4 +101,4 @@ export {
   DialogFooter,
   DialogTitle,
   DialogDescription,
-}
+};

--- a/dcapal-frontend/src/components/ui/input.jsx
+++ b/dcapal-frontend/src/components/ui/input.jsx
@@ -2,6 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
+/** @type {React.ForwardRefExoticComponent<React.InputHTMLAttributes<HTMLInputElement> & React.RefAttributes<HTMLInputElement>>} */
 const Input = React.forwardRef(({ className, type, ...props }, ref) => {
   return (
     (<input

--- a/dcapal-frontend/src/components/ui/tooltip.jsx
+++ b/dcapal-frontend/src/components/ui/tooltip.jsx
@@ -3,7 +3,9 @@ import * as TooltipPrimitive from "@radix-ui/react-tooltip"
 
 import { cn } from "@/lib/utils"
 
-const TooltipProvider = TooltipPrimitive.Provider
+const TooltipProvider = ({ delayDuration = 200, ...props }) => (
+  <TooltipPrimitive.Provider delayDuration={delayDuration} {...props} />
+)
 
 const Tooltip = TooltipPrimitive.Root
 

--- a/dcapal-frontend/tests/journeys/create-portfolio.spec.ts
+++ b/dcapal-frontend/tests/journeys/create-portfolio.spec.ts
@@ -6,7 +6,11 @@ const startNewPortfolio = async (
   currency = "eur"
 ): Promise<void> => {
   await page.goto("/");
-  await page.getByTestId("importStep.allocateYourSavings").first().click();
+  const allocateButton = page
+    .getByTestId("importStep.allocateYourSavings")
+    .first();
+  await expect(allocateButton).toHaveCSS("cursor", "pointer");
+  await allocateButton.click();
 
   const form = page.getByTestId("new-portfolio-form");
   await expect(form).toBeVisible();

--- a/dcapal-frontend/tests/journeys/edit-portfolio.spec.ts
+++ b/dcapal-frontend/tests/journeys/edit-portfolio.spec.ts
@@ -84,25 +84,36 @@ test("an investor edits quantities, prices, and allocation weights", async ({
   );
 
   const mwrHelp = page.getByRole("button", { name: "MWR" });
-  const tooltip = page.getByRole("tooltip");
   await expect(mwrHelp).toHaveCSS("cursor", "pointer");
-  await mwrHelp.click();
-  await expect(tooltip).toBeVisible({ timeout: 500 });
-  await expect(mwrHelp).toHaveAttribute("aria-expanded", "true");
-  await mwrHelp.click();
-  await expect(mwrHelp).toHaveAttribute("aria-expanded", "false");
-  await expect(tooltip).toBeHidden();
-  await page.mouse.move(40, 120);
-  await mwrHelp.hover();
-  await expect(tooltip).toBeVisible({ timeout: 500 });
-  await page.keyboard.press("Escape");
-  await expect(mwrHelp).toHaveAttribute("aria-expanded", "false");
-  await expect(tooltip).toBeHidden();
-  await mwrHelp.click();
-  await expect(tooltip).toBeVisible({ timeout: 500 });
-  await page.mouse.click(40, 120);
-  await expect(mwrHelp).toHaveAttribute("aria-expanded", "false");
-  await expect(tooltip).toBeHidden();
+  if ((page.viewportSize()?.width ?? 1024) < 768) {
+    const helpDrawer = page.getByRole("dialog");
+    await mwrHelp.click();
+    await expect(helpDrawer).toBeVisible();
+    await expect(helpDrawer).toContainText(
+      /Money-Weighted Return|Rendimento ponderato/
+    );
+    await page.keyboard.press("Escape");
+    await expect(helpDrawer).toBeHidden();
+  } else {
+    const tooltip = page.getByRole("tooltip");
+    await mwrHelp.click();
+    await expect(tooltip).toBeVisible({ timeout: 500 });
+    await expect(mwrHelp).toHaveAttribute("aria-expanded", "true");
+    await mwrHelp.click();
+    await expect(mwrHelp).toHaveAttribute("aria-expanded", "false");
+    await expect(tooltip).toBeHidden();
+    await page.mouse.move(40, 120);
+    await mwrHelp.hover();
+    await expect(tooltip).toBeVisible({ timeout: 500 });
+    await page.keyboard.press("Escape");
+    await expect(mwrHelp).toHaveAttribute("aria-expanded", "false");
+    await expect(tooltip).toBeHidden();
+    await mwrHelp.click();
+    await expect(tooltip).toBeVisible({ timeout: 500 });
+    await page.mouse.click(40, 120);
+    await expect(mwrHelp).toHaveAttribute("aria-expanded", "false");
+    await expect(tooltip).toBeHidden();
+  }
 
   const equity = page.locator('[data-testid="asset-card"][data-symbol="VWCE"]');
   const bond = page.locator('[data-testid="asset-card"][data-symbol="AGGH"]');

--- a/dcapal-frontend/tests/journeys/edit-portfolio.spec.ts
+++ b/dcapal-frontend/tests/journeys/edit-portfolio.spec.ts
@@ -50,6 +50,60 @@ test("an investor edits quantities, prices, and allocation weights", async ({
   });
   await page.goto("/allocate");
 
+  await expect(page.getByTestId("portfolio-search")).toHaveCSS(
+    "background-color",
+    "rgb(255, 255, 255)"
+  );
+  await expect(page.getByTestId("portfolio-search")).toHaveCSS(
+    "font-size",
+    "16px"
+  );
+  await expect(page.getByTestId("portfolio-search")).toHaveCSS(
+    "padding-top",
+    "0px"
+  );
+  await expect(page.getByTestId("portfolio-search")).toHaveCSS(
+    "padding-bottom",
+    "0px"
+  );
+  await expect(page.getByTestId("portfolio-preferences")).toHaveCSS(
+    "cursor",
+    "pointer"
+  );
+  await expect(page.locator("button:has(svg.lucide-save)")).toHaveCSS(
+    "cursor",
+    "pointer"
+  );
+  await expect(page.getByRole("button", { name: "Go back" })).toHaveCSS(
+    "cursor",
+    "pointer"
+  );
+  await expect(page.getByRole("button", { name: "Confirm weights" })).toHaveCSS(
+    "cursor",
+    "pointer"
+  );
+
+  const mwrHelp = page.getByRole("button", { name: "MWR" });
+  const tooltip = page.getByRole("tooltip");
+  await expect(mwrHelp).toHaveCSS("cursor", "pointer");
+  await mwrHelp.click();
+  await expect(tooltip).toBeVisible({ timeout: 500 });
+  await expect(mwrHelp).toHaveAttribute("aria-expanded", "true");
+  await mwrHelp.click();
+  await expect(mwrHelp).toHaveAttribute("aria-expanded", "false");
+  await expect(tooltip).toBeHidden();
+  await page.mouse.move(40, 120);
+  await mwrHelp.hover();
+  await expect(tooltip).toBeVisible({ timeout: 500 });
+  await page.keyboard.press("Escape");
+  await expect(mwrHelp).toHaveAttribute("aria-expanded", "false");
+  await expect(tooltip).toBeHidden();
+  await mwrHelp.click();
+  await expect(tooltip).toBeVisible({ timeout: 500 });
+  await page.mouse.click(40, 120);
+  await expect(mwrHelp).toHaveAttribute("aria-expanded", "false");
+  await expect(tooltip).toBeHidden();
+
   const equity = page.locator('[data-testid="asset-card"][data-symbol="VWCE"]');
   const bond = page.locator('[data-testid="asset-card"][data-symbol="AGGH"]');
   await expect(equity).toBeVisible();
@@ -94,6 +148,10 @@ test("the editor distinguishes under, exact, and over allocation", async ({
   await expect(
     page.getByRole("button", { name: "Confirm weights" })
   ).toBeDisabled();
+  await expect(page.getByRole("button", { name: "Confirm weights" })).toHaveCSS(
+    "cursor",
+    "not-allowed"
+  );
 
   await equity.getByRole("spinbutton").nth(2).fill("40");
   await equity.getByRole("spinbutton").nth(2).blur();

--- a/dcapal-frontend/tests/journeys/transaction-fees.spec.ts
+++ b/dcapal-frontend/tests/journeys/transaction-fees.spec.ts
@@ -16,6 +16,10 @@ const openFeePreferences = async (page: Page): Promise<Locator> => {
   await page.getByTestId("portfolio-preferences").click();
   const dialog = page.getByRole("dialog");
   await expect(dialog).toBeVisible();
+  await expect(dialog.getByRole("button", { name: "Close" })).toHaveCSS(
+    "cursor",
+    "pointer"
+  );
   return dialog;
 };
 
@@ -72,7 +76,12 @@ test("an investor can override fees for one asset and return to the default", as
   const asset = page.locator(
     '[data-testid="asset-card"][data-symbol="VWCE.MI"]'
   );
-  await asset.getByTestId("transaction-fees").click();
+  const transactionFees = asset.getByTestId("transaction-fees");
+  await expect(transactionFees).toHaveCSS("cursor", "pointer");
+  await expect(transactionFees).toHaveAttribute("aria-expanded", "false");
+  await transactionFees.focus();
+  await page.keyboard.press("Enter");
+  await expect(transactionFees).toHaveAttribute("aria-expanded", "true");
   await asset.getByText("Fixed", { exact: true }).click();
   const fields = asset.getByRole("spinbutton");
   await fields.nth(4).fill("2");


### PR DESCRIPTION
## Summary

Improve portfolio workflow controls so interactive elements are keyboard-accessible, consistently styled, and provide clearer feedback across desktop and mobile layouts.

## Related Issues

None

## Changes Made

- Convert transaction-fee toggles and help icons to accessible buttons.
- Support controlled tooltip click, hover, Escape, and outside-click behavior.
- Standardize input, button, dialog, and disabled-control cursor styling.
- Add responsive search input styling and stronger ref typing.
- Extend portfolio journeys to verify accessibility and visual interaction states.

## Motivation

Several controls were styled or implemented as non-interactive elements, making their behavior unclear and limiting keyboard and pointer feedback. These changes align the controls with their actual behavior and protect the expected interaction states with end-to-end coverage.

## Design decisions

- Use native buttons for actionable controls and preserve Radix tooltip and drawer behavior.
- Keep tooltip behavior controlled so repeated clicks toggle predictably without duplicate close events.
- Reuse the shared `Input` component and central button styles for consistent UI behavior.

## Validation

- **Interactive portfolio controls:** `GIVEN` an investor is editing a portfolio, `WHEN` they inspect and use search, navigation, save, confirmation, and help controls, `THEN` expected cursor, focus, tooltip, and disabled states are available.
- **Transaction fee preferences:** `GIVEN` an asset card and fee preferences dialog, `WHEN` the investor opens controls with keyboard or pointer input, `THEN` the controls expose the expected expanded state and interaction styling.
- **Portfolio creation:** `GIVEN` the new portfolio flow, `WHEN` the investor reaches the allocation action, `THEN` the action is identified as clickable.

## Testing

Updated Playwright journey coverage for portfolio creation, portfolio editing, tooltips, transaction fees, keyboard activation, and control styling.