### PR TITLE
fix(metrics): use route templates to limit metric label cardinality

### DIFF
--- a/dcapal-backend/crates/backend/src/app/infra/stats.rs
+++ b/dcapal-backend/crates/backend/src/app/infra/stats.rs
@@ -6,7 +6,7 @@ use std::{
 
 use crate::{AppContext, error::Result, ports::outbound::repository::StatsRepository};
 use axum::{
-    extract::{ConnectInfo, Request, State},
+    extract::{ConnectInfo, MatchedPath, Request, State},
     middleware::Next,
     response::Response,
 };
@@ -24,7 +24,7 @@ pub const LATENCY_SUMMARY: &str = concatcp!(BASE, '_', "latency_summary");
 pub const IMPORTED_PORTFOLIOS_TOTAL: &str = concatcp!(BASE, '_', "imported_portfolios_total");
 
 pub async fn latency_stats(req: Request, next: Next) -> Response {
-    let path = req.uri().path().to_string();
+    let path = metric_path(&req);
     if path == "/" {
         return next.run(req).await;
     }
@@ -44,7 +44,7 @@ pub async fn requests_stats(
     req: Request,
     next: Next,
 ) -> Result<Response> {
-    let path = req.uri().path().to_string();
+    let path = metric_path(&req);
     if path == "/" {
         return Ok(next.run(req).await);
     }
@@ -56,6 +56,15 @@ pub async fn requests_stats(
     record_visitors_stats(req.headers(), addr, state.repos.stats.clone()).await?;
 
     Ok(next.run(req).await)
+}
+
+/// Returns the matched route template, or the request path when no template is available.
+fn metric_path(req: &Request) -> String {
+    req.extensions()
+        .get::<MatchedPath>()
+        .map(MatchedPath::as_str)
+        .unwrap_or_else(|| req.uri().path())
+        .to_owned()
 }
 
 async fn record_visitors_stats(
@@ -89,4 +98,107 @@ async fn record_visitors_stats(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        Router,
+        body::Body,
+        http::{Request, StatusCode},
+        middleware,
+        response::Response,
+        routing::get,
+    };
+    use tower::ServiceExt;
+
+    use super::*;
+
+    async fn expose_metric_path(req: Request<Body>, next: Next) -> Response {
+        let path = metric_path(&req);
+        let mut response = next.run(req).await;
+        response.headers_mut().insert(
+            "x-metric-path",
+            path.parse().expect("metric paths are valid header values"),
+        );
+        response
+    }
+
+    async fn matched_metric_path(route: &'static str, request_path: &'static str) -> String {
+        let app = Router::new()
+            .route(route, get(|| async {}))
+            .route_layer(middleware::from_fn(expose_metric_path));
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri(request_path)
+                    .body(Body::empty())
+                    .expect("request should be valid"),
+            )
+            .await
+            .expect("router should respond");
+
+        response
+            .headers()
+            .get("x-metric-path")
+            .expect("middleware should expose the metric path")
+            .to_str()
+            .expect("metric path should be valid UTF-8")
+            .to_owned()
+    }
+
+    #[tokio::test]
+    async fn uses_route_templates_for_dynamic_endpoints() {
+        // GIVEN requests to parameterized endpoints, WHEN Axum provides their
+        // matched paths, THEN metrics use the route templates.
+        for (route, request_path) in [
+            ("/assets/chart/{symbol}", "/assets/chart/BTC-USD"),
+            ("/price/{asset}", "/price/EUR"),
+            ("/import/portfolio/{id}", "/import/portfolio/42"),
+        ] {
+            assert_eq!(matched_metric_path(route, request_path).await, route);
+        }
+    }
+
+    #[tokio::test]
+    async fn uses_static_matched_paths() {
+        // GIVEN a request to a static endpoint, WHEN its route is matched,
+        // THEN the static route path is used for metrics.
+        assert_eq!(
+            matched_metric_path("/health", "/health?check=ready").await,
+            "/health"
+        );
+    }
+
+    #[test]
+    fn falls_back_to_the_request_path_without_a_matched_path() {
+        // GIVEN a request without a MatchedPath extension, WHEN its metric path
+        // is resolved, THEN the URI path is used as the fallback.
+        let request = Request::builder()
+            .uri("/not-routed?check=ready")
+            .body(Body::empty())
+            .expect("request should be valid");
+
+        assert_eq!(metric_path(&request), "/not-routed");
+    }
+
+    #[tokio::test]
+    async fn excludes_the_root_path_from_latency_metrics() {
+        // GIVEN a request for the root endpoint, WHEN latency middleware runs,
+        // THEN it passes through without requiring a metrics recorder.
+        let app = Router::new()
+            .route("/", get(|| async { StatusCode::NO_CONTENT }))
+            .layer(middleware::from_fn(latency_stats));
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .body(Body::empty())
+                    .expect("request should be valid"),
+            )
+            .await
+            .expect("router should respond");
+
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    }
 }


### PR DESCRIPTION
## Summary

Use matched route templates for request and latency metric labels so dynamic URL values do not create high-cardinality metrics.

## Related Issues

None

## Changes Made

- Resolve metric paths from Axum's `MatchedPath` extension.
- Fall back to the request URI path when no matched route is available.
- Preserve the existing root-path exclusion from latency metrics.
- Add coverage for dynamic routes, static routes, fallback behavior, and root requests.

## Motivation

Using raw request paths causes each distinct path parameter to produce a separate metric label value. Route templates group equivalent requests and keep metric cardinality bounded.

## Design decisions

- Keep the URI path as a fallback for middleware contexts where Axum has not provided a matched route.
- Do not change metric names, recording behavior, or endpoint routing.

## Validation

- **Dynamic endpoints:** `GIVEN` parameterized requests, `WHEN` their routes are matched, `THEN` metrics use route templates.
- **Static endpoints:** `GIVEN` a static request with a query string, `WHEN` its route is matched, `THEN` metrics use the static route path without query parameters.
- **Fallback:** `GIVEN` no matched-path extension, `WHEN` the metric path is resolved, `THEN` the URI path is used.
- **Root endpoint:** `GIVEN` a root request, `WHEN` latency middleware runs, `THEN` the request passes through without metric recording.