### PR TITLE
feat(markets): reconcile stale Kraken markets hourly

### DIFF
--- a/dcapal-backend/crates/backend/src/app/services/market_data.rs
+++ b/dcapal-backend/crates/backend/src/app/services/market_data.rs
@@ -19,6 +19,8 @@ use crate::{
     ports::outbound::repository::market_data::MarketDataRepository,
 };
 
+const MAX_MARKET_LOAD_ATTEMPTS: usize = 3;
+
 /// Provides cached access to market assets, markets, and conversion rates.
 pub struct MarketDataService {
     repo: Arc<MarketDataRepository>,
@@ -123,34 +125,42 @@ impl MarketDataService {
 
     /// Lookup a [`Market`] by [`MarketId`]
     pub async fn get_market(&self, id: &MarketId) -> Result<Option<Arc<Market>>> {
-        let generation = self.market_cache_generation.load(Ordering::Acquire);
-        {
-            let markets = self.markets.read();
-            if let Some(market) = markets.get(id)
-                && self.market_cache_generation.load(Ordering::Acquire) == generation
+        for _ in 0..MAX_MARKET_LOAD_ATTEMPTS {
+            let generation = self.market_cache_generation.load(Ordering::Acquire);
             {
-                return Ok(Some(market.clone()));
+                let markets = self.markets.read();
+                if let Some(market) = markets.get(id)
+                    && self.market_cache_generation.load(Ordering::Acquire) == generation
+                {
+                    return Ok(Some(market.clone()));
+                }
             }
+
+            let market = match self.load_market(id).await {
+                Ok(m) => m,
+                Err(e) => {
+                    error!("{:?}", e);
+                    None
+                }
+            };
+
+            let Some(market) = market else {
+                return Ok(None);
+            };
+
+            let mut markets = self.markets.write();
+            if self.market_cache_generation.load(Ordering::Acquire) != generation {
+                continue;
+            }
+            markets.insert(id.clone(), market.clone());
+            return Ok(Some(market));
         }
 
-        let market = match self.load_market(id).await {
-            Ok(m) => m,
-            Err(e) => {
-                error!("{:?}", e);
-                None
-            }
-        };
-
-        let Some(market) = market else {
-            return Ok(None);
-        };
-
-        let mut markets = self.markets.write();
-        if self.market_cache_generation.load(Ordering::Acquire) != generation {
-            return Ok(None);
-        }
-        markets.insert(id.clone(), market.clone());
-        Ok(Some(market))
+        info!(
+            mkt = id,
+            "Market cache generation changed during every load attempt"
+        );
+        Ok(None)
     }
 
     async fn load_market(&self, id: &MarketId) -> Result<Option<Arc<Market>>> {

--- a/dcapal-backend/crates/backend/src/app/services/market_data.rs
+++ b/dcapal-backend/crates/backend/src/app/services/market_data.rs
@@ -1,4 +1,10 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+};
 
 use chrono::Utc;
 use parking_lot::RwLock;
@@ -13,9 +19,11 @@ use crate::{
     ports::outbound::repository::market_data::MarketDataRepository,
 };
 
+/// Provides cached access to market assets, markets, and conversion rates.
 pub struct MarketDataService {
     repo: Arc<MarketDataRepository>,
     markets: RwLock<HashMap<MarketId, Arc<Market>>>,
+    market_cache_generation: AtomicU64,
     pricers: RwLock<HashMap<(AssetId, AssetId), Option<Price>>>,
     price_deps: RwLock<HashMap<MarketId, Vec<(AssetId, AssetId)>>>,
     assets_cache: RwLock<AssetsCache>,
@@ -31,6 +39,7 @@ impl MarketDataService {
         Self {
             repo,
             markets,
+            market_cache_generation: AtomicU64::new(0),
             pricers,
             price_deps,
             assets_cache,
@@ -83,11 +92,43 @@ impl MarketDataService {
         cache.fiats = None;
     }
 
+    /// Clears cached markets and conversion rates after market reconciliation.
+    pub fn invalidate_market_cache(&self) {
+        self.market_cache_generation.fetch_add(1, Ordering::AcqRel);
+        self.markets.write().clear();
+        self.pricers.write().clear();
+        self.price_deps.write().clear();
+    }
+
+    /// Removes deleted markets and conversion rates that depend on them.
+    pub fn invalidate_markets(&self, ids: &[MarketId]) {
+        self.market_cache_generation.fetch_add(1, Ordering::AcqRel);
+        {
+            let mut markets = self.markets.write();
+            for id in ids {
+                markets.remove(id);
+            }
+        }
+
+        let mut pricers = self.pricers.write();
+        let mut price_deps = self.price_deps.write();
+        for id in ids {
+            if let Some(deps) = price_deps.remove(id) {
+                for dep in deps {
+                    pricers.remove(&dep);
+                }
+            }
+        }
+    }
+
     /// Lookup a [`Market`] by [`MarketId`]
     pub async fn get_market(&self, id: &MarketId) -> Result<Option<Arc<Market>>> {
+        let generation = self.market_cache_generation.load(Ordering::Acquire);
         {
             let markets = self.markets.read();
-            if let Some(market) = markets.get(id) {
+            if let Some(market) = markets.get(id)
+                && self.market_cache_generation.load(Ordering::Acquire) == generation
+            {
                 return Ok(Some(market.clone()));
             }
         }
@@ -105,6 +146,9 @@ impl MarketDataService {
         };
 
         let mut markets = self.markets.write();
+        if self.market_cache_generation.load(Ordering::Acquire) != generation {
+            return Ok(None);
+        }
         markets.insert(id.clone(), market.clone());
         Ok(Some(market))
     }
@@ -345,5 +389,57 @@ impl AssetsCache {
             fiats: None,
             crypto: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+
+    #[test]
+    fn invalidating_a_market_removes_it_and_dependent_conversion_rates() {
+        // GIVEN a cached market and a synthetic conversion rate that depends on it
+        let pool = deadpool_redis::Config::from_url("redis://localhost/")
+            .builder()
+            .unwrap()
+            .build()
+            .unwrap();
+        let repo = Arc::new(MarketDataRepository::new(pool));
+        let service = MarketDataService::new(repo);
+        let market_id = "unieur".to_string();
+        let dependency = ("uni".to_string(), "eur".to_string());
+        let market = Market::new(
+            market_id.clone(),
+            Asset::Crypto(crate::app::domain::entity::Crypto::new_with_id(
+                "uni".into(),
+            )),
+            Asset::Fiat(crate::app::domain::entity::Fiat::new(
+                "eur".into(),
+                "Euro".into(),
+            )),
+            None,
+        );
+        service
+            .markets
+            .write()
+            .insert(market_id.clone(), Arc::new(market));
+        service
+            .pricers
+            .write()
+            .insert(dependency.clone(), Some(Price::new(1., Utc::now())));
+        service
+            .price_deps
+            .write()
+            .insert(market_id.clone(), vec![dependency.clone()]);
+
+        // WHEN the deleted market is invalidated
+        service.invalidate_markets(std::slice::from_ref(&market_id));
+
+        // THEN the market and its dependent conversion rate are no longer cached
+        assert!(!service.markets.read().contains_key(&market_id));
+        assert!(!service.pricers.read().contains_key(&dependency));
+        assert!(!service.price_deps.read().contains_key(&market_id));
     }
 }

--- a/dcapal-backend/crates/backend/src/app/workers/market_discovery.rs
+++ b/dcapal-backend/crates/backend/src/app/workers/market_discovery.rs
@@ -1,7 +1,7 @@
 use std::{sync::Arc, time::Duration};
 
 use chrono::{NaiveDate, TimeZone, Utc};
-use tokio::time::{Instant, MissedTickBehavior};
+use tokio::time::Instant;
 use tracing::{debug, error, info};
 
 use crate::{
@@ -60,7 +60,6 @@ impl MarketDiscoveryWorker {
     async fn run_market_reconciliation(&self, stop_token: &mut StopToken) {
         let mut interval =
             tokio::time::interval_at(Instant::now() + INITIAL_DELAY, HOURLY_INTERVAL);
-        interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
         loop {
             tokio::select! {
@@ -77,7 +76,6 @@ impl MarketDiscoveryWorker {
     async fn run_market_discovery(&self, stop_token: &mut StopToken) {
         let mut interval =
             tokio::time::interval_at(Instant::now() + INITIAL_DELAY, DAILY_CHECK_INTERVAL);
-        interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
         loop {
             tokio::select! {

--- a/dcapal-backend/crates/backend/src/app/workers/market_discovery.rs
+++ b/dcapal-backend/crates/backend/src/app/workers/market_discovery.rs
@@ -1,6 +1,7 @@
 use std::{sync::Arc, time::Duration};
 
-use chrono::{TimeZone, Utc};
+use chrono::{NaiveDate, TimeZone, Utc};
+use tokio::time::{Instant, MissedTickBehavior};
 use tracing::{debug, error, info};
 
 use crate::{
@@ -18,8 +19,11 @@ use crate::{
     },
 };
 
-/// Worker to periodically discover new crypto assets and markets. As of today,
-/// new markets are checked every 24 hours.
+const INITIAL_DELAY: Duration = Duration::from_millis(50);
+const DAILY_CHECK_INTERVAL: Duration = Duration::from_secs(60);
+const HOURLY_INTERVAL: Duration = Duration::from_secs(60 * 60);
+
+/// Worker that reconciles Kraken markets hourly and discovers new assets daily.
 pub struct MarketDiscoveryWorker {
     market_data_service: Arc<MarketDataService>,
     misc_repo: Arc<MiscRepository>,
@@ -46,16 +50,40 @@ impl MarketDiscoveryWorker {
     }
 
     pub async fn run(&self, mut stop_token: StopToken) {
-        let mut sleep = tokio::time::sleep(Duration::from_millis(50));
+        let mut reconciliation_stop_token = stop_token.clone();
+        let reconciliation = self.run_market_reconciliation(&mut reconciliation_stop_token);
+        let discovery = self.run_market_discovery(&mut stop_token);
+
+        tokio::join!(reconciliation, discovery);
+    }
+
+    async fn run_market_reconciliation(&self, stop_token: &mut StopToken) {
+        let mut interval =
+            tokio::time::interval_at(Instant::now() + INITIAL_DELAY, HOURLY_INTERVAL);
+        interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
         loop {
             tokio::select! {
-                _ = sleep => {}
-                _ = should_stop(&mut stop_token) => break,
+                _ = interval.tick() => {}
+                _ = should_stop(stop_token) => break,
             }
 
-            // Reset next check timeout
-            sleep = tokio::time::sleep(Duration::from_secs(60));
+            if let Err(e) = self.reconcile_markets().await {
+                error!("Failed to reconcile Kraken markets: {:?}", e);
+            }
+        }
+    }
+
+    async fn run_market_discovery(&self, stop_token: &mut StopToken) {
+        let mut interval =
+            tokio::time::interval_at(Instant::now() + INITIAL_DELAY, DAILY_CHECK_INTERVAL);
+        interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
+        loop {
+            tokio::select! {
+                _ = interval.tick() => {}
+                _ = should_stop(stop_token) => break,
+            }
 
             let res = is_outdated(&self.misc_repo).await;
             if let Err(e) = res {
@@ -74,16 +102,32 @@ impl MarketDiscoveryWorker {
 
             if let Err(e) = self.discover_new_markets().await {
                 error!("Failed to update Kraken Assets and Markets data: {:?}", e);
+            } else {
+                let now = Utc::now();
+                if let Err(e) = self.misc_repo.set_cw_last_fetched(now).await {
+                    error!("Failed to update last update time: {:?}", e);
+                }
             }
-
-            let now = Utc::now();
-            if let Err(e) = self.misc_repo.set_cw_last_fetched(now).await {
-                error!("Failed to update last update time: {:?}", e);
-            }
-
-            // Reset next check timeout
-            sleep = tokio::time::sleep(Duration::from_secs(60));
         }
+    }
+
+    async fn reconcile_markets(&self) -> Result<()> {
+        let market_ids = self.providers.kraken.fetch_tradable_market_ids().await?;
+        let deleted = self
+            .market_data_repo
+            .delete_markets_not_in(&market_ids)
+            .await?;
+
+        if !deleted.is_empty() {
+            info!(
+                "Removed {} stale Kraken markets from Redis: {:?}",
+                deleted.len(),
+                deleted
+            );
+            self.market_data_service.invalidate_markets(&deleted);
+        }
+
+        Ok(())
     }
 
     async fn discover_new_markets(&self) -> Result<()> {
@@ -132,6 +176,7 @@ impl MarketDiscoveryWorker {
         }
 
         self.market_data_service.invalidate_asset_cache();
+        self.market_data_service.invalidate_market_cache();
 
         Ok(())
     }
@@ -139,11 +184,61 @@ impl MarketDiscoveryWorker {
 
 async fn is_outdated(misc: &MiscRepository) -> Result<(bool, Option<DateTime>)> {
     let last_fetched = misc.get_cw_last_fetched().await?;
-    if let Some(ts) = last_fetched {
-        let ts_day = Utc.from_utc_datetime(&ts.naive_utc()).date_naive();
-        let today = Utc::now().date_naive();
-        return Ok((ts_day < today, Some(ts)));
+    let today = Utc::now().date_naive();
+    Ok((is_outdated_at(last_fetched, today), last_fetched))
+}
+
+fn is_outdated_at(last_fetched: Option<DateTime>, today: NaiveDate) -> bool {
+    last_fetched
+        .map(|ts| Utc.from_utc_datetime(&ts.naive_utc()).date_naive() < today)
+        .unwrap_or(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{NaiveDate, TimeZone, Utc};
+
+    use super::{HOURLY_INTERVAL, is_outdated_at};
+
+    #[test]
+    fn missing_daily_marker_is_outdated() {
+        // GIVEN daily discovery has never completed
+        // WHEN the worker checks the marker
+        let outdated = is_outdated_at(None, NaiveDate::from_ymd_opt(2026, 9, 2).unwrap());
+
+        // THEN discovery is due
+        assert!(outdated);
     }
 
-    Ok((true, None))
+    #[test]
+    fn same_day_daily_marker_is_not_outdated() {
+        // GIVEN daily discovery completed earlier on the current UTC date
+        let last_fetched = Utc.with_ymd_and_hms(2026, 9, 2, 1, 2, 3).single();
+
+        // WHEN the worker checks the marker
+        let outdated = is_outdated_at(last_fetched, NaiveDate::from_ymd_opt(2026, 9, 2).unwrap());
+
+        // THEN discovery is not repeated until the next UTC date
+        assert!(!outdated);
+    }
+
+    #[test]
+    fn previous_day_daily_marker_is_outdated() {
+        // GIVEN daily discovery completed on the previous UTC date
+        let last_fetched = Utc.with_ymd_and_hms(2026, 9, 1, 23, 59, 59).single();
+
+        // WHEN the worker checks the marker
+        let outdated = is_outdated_at(last_fetched, NaiveDate::from_ymd_opt(2026, 9, 2).unwrap());
+
+        // THEN discovery is due again
+        assert!(outdated);
+    }
+
+    #[test]
+    fn market_reconciliation_runs_hourly() {
+        // GIVEN the market reconciliation schedule
+        // WHEN its interval is read
+        // THEN the worker waits one hour between runs
+        assert_eq!(HOURLY_INTERVAL, std::time::Duration::from_secs(3600));
+    }
 }

--- a/dcapal-backend/crates/backend/src/ports/outbound/adapter/kraken.rs
+++ b/dcapal-backend/crates/backend/src/ports/outbound/adapter/kraken.rs
@@ -49,23 +49,7 @@ impl KrakenProvider {
 
         // Fetch Kraken markets
         debug!(url = URL, "Fetching markets from Kraken");
-        let Some(res) = self.fetch_kraken_api::<AssetPairsResponse>(URL).await? else {
-            return Err(DcaError::Generic("AssetPairs not found".to_string()));
-        };
-
-        if !res.error.is_empty() {
-            error!("Error occurred while fetching asset pairs: {:?}", res.error);
-            return Err(DcaError::Generic(format!("{:?}", res.error)));
-        }
-
-        // Filter online market symbols and rename Kraken specific pairs to standard
-        // names
-        let market_symbols = res
-            .result
-            .values()
-            .filter(|&p| p.status == "online")
-            .map(|p| normalize_symbol(&p.wsname))
-            .collect::<Vec<String>>();
+        let market_symbols = self.fetch_online_market_symbols(URL).await?;
 
         let (markets, assets) = if self.cmc_api_key.is_some() {
             // If CoinMarketCap API key is available, enrich assets data with human-friendly
@@ -81,6 +65,28 @@ impl KrakenProvider {
         debug!("New markets: {}", serde_json::to_string(&markets).unwrap());
 
         Ok((assets, markets))
+    }
+
+    /// Fetches the complete set of currently online Kraken market ids.
+    pub async fn fetch_tradable_market_ids(&self) -> Result<HashSet<MarketId>> {
+        static URL: &str = "https://api.kraken.com/0/public/AssetPairs";
+
+        debug!(url = URL, "Fetching market snapshot from Kraken");
+        let market_symbols = self.fetch_online_market_symbols(URL).await?;
+        market_ids_from_symbols(&market_symbols)
+    }
+
+    async fn fetch_online_market_symbols(&self, url: &str) -> Result<Vec<String>> {
+        let Some(res) = self.fetch_kraken_api::<AssetPairsResponse>(url).await? else {
+            return Err(DcaError::Generic("AssetPairs not found".to_string()));
+        };
+
+        if !res.error.is_empty() {
+            error!("Error occurred while fetching asset pairs: {:?}", res.error);
+            return Err(DcaError::Generic(format!("{:?}", res.error)));
+        }
+
+        parse_online_market_symbols(&res)
     }
 
     pub async fn fetch_market_price(&self, mkt: &Market, ts: DateTime) -> Result<Option<f64>> {
@@ -430,6 +436,83 @@ fn normalize_symbol(wsname: &str) -> String {
         .to_lowercase()
 }
 
+#[derive(Debug, PartialEq, Eq)]
+struct MarketSymbol<'a> {
+    base: &'a str,
+    quote: &'a str,
+    venue: Option<&'a str>,
+}
+
+/// Parses a Kraken websocket name into base, quote, and an optional venue.
+fn parse_market_symbol(symbol: &str) -> Option<MarketSymbol<'_>> {
+    let (base, quote_and_venue) = symbol.split_once('/')?;
+    let (quote, venue) = match quote_and_venue.split_once(':') {
+        Some((quote, venue)) => (quote, Some(venue)),
+        None => (quote_and_venue, None),
+    };
+
+    let valid_component =
+        |component: &str| !component.is_empty() && !component.chars().any(char::is_whitespace);
+
+    if !valid_component(base)
+        || base.contains(':')
+        || !valid_component(quote)
+        || quote.contains('/')
+        || venue.is_some_and(|venue| {
+            !valid_component(venue) || venue.contains('/') || venue.contains(':')
+        })
+    {
+        return None;
+    }
+
+    Some(MarketSymbol { base, quote, venue })
+}
+
+fn parse_online_market_symbols(response: &AssetPairsResponse) -> Result<Vec<String>> {
+    let symbols = response
+        .result
+        .values()
+        .filter(|pair| pair.status == "online")
+        .filter_map(|pair| {
+            let symbol = normalize_symbol(&pair.wsname);
+            let Some(parsed) = parse_market_symbol(&symbol) else {
+                warn!(symbol, "Ignoring malformed online Kraken market");
+                return None;
+            };
+            Some(format!("{}/{}", parsed.base, parsed.quote))
+        })
+        .collect::<Vec<_>>();
+
+    if symbols.is_empty() {
+        return Err(DcaError::Generic(
+            "Kraken returned no online markets".to_string(),
+        ));
+    }
+
+    Ok(symbols)
+}
+
+fn market_ids_from_symbols(market_symbols: &[String]) -> Result<HashSet<MarketId>> {
+    let ids = market_symbols
+        .iter()
+        .filter_map(|symbol| {
+            let Some(parsed) = parse_market_symbol(symbol) else {
+                warn!(symbol, "Ignoring malformed online Kraken market");
+                return None;
+            };
+            Some(format!("{}{}", parsed.base, parsed.quote))
+        })
+        .collect::<HashSet<_>>();
+
+    if ids.is_empty() {
+        return Err(DcaError::Generic(
+            "Kraken returned no online markets".to_string(),
+        ));
+    }
+
+    Ok(ids)
+}
+
 type MarketPair = (String, String);
 
 fn split_base_quote(market_symbols: &[String]) -> Vec<MarketPair> {
@@ -601,4 +684,166 @@ struct CMCInfoData {
     id: u64,
     symbol: String,
     name: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{HashMap, HashSet};
+
+    use super::{
+        AssetPairsResponse, MarketSymbol, Pair, market_ids_from_symbols, parse_market_symbol,
+        parse_online_market_symbols,
+    };
+
+    #[test]
+    fn online_pair_snapshot_is_normalized_and_filters_offline_pairs() {
+        // GIVEN Kraken returns online pairs in an arbitrary map order, including an XBT pair
+        let response = AssetPairsResponse {
+            error: vec![],
+            result: HashMap::from([
+                (
+                    "xbt-usd".to_string(),
+                    Pair {
+                        wsname: "XBT/EUR".to_string(),
+                        status: "online".to_string(),
+                    },
+                ),
+                (
+                    "eth-eur".to_string(),
+                    Pair {
+                        wsname: "ETH/EUR:darkpool".to_string(),
+                        status: "online".to_string(),
+                    },
+                ),
+                (
+                    "ada-usd".to_string(),
+                    Pair {
+                        wsname: "ADA/USD".to_string(),
+                        status: "online".to_string(),
+                    },
+                ),
+                (
+                    "old".to_string(),
+                    Pair {
+                        wsname: "BTC/GBP".to_string(),
+                        status: "offline".to_string(),
+                    },
+                ),
+            ]),
+        };
+
+        // WHEN the online pairs are parsed into a snapshot
+        let symbols = parse_online_market_symbols(&response).unwrap();
+        let ids = market_ids_from_symbols(&symbols).unwrap();
+
+        // THEN offline pairs are excluded and the result is normalized
+        assert_eq!(
+            symbols.into_iter().collect::<HashSet<_>>(),
+            ["btc/eur", "eth/eur", "ada/usd"]
+                .into_iter()
+                .map(String::from)
+                .collect()
+        );
+        assert_eq!(
+            ids,
+            [
+                "btceur".to_string(),
+                "etheur".to_string(),
+                "adausd".to_string()
+            ]
+            .into_iter()
+            .collect()
+        );
+    }
+
+    #[test]
+    fn market_symbol_parser_retains_optional_venue_separately() {
+        // GIVEN a normalized Kraken symbol with an optional venue
+        // WHEN the symbol is parsed
+        let parsed = parse_market_symbol("btc/eur:darkpool");
+
+        // THEN the base, quote, and venue are separated
+        assert_eq!(
+            parsed,
+            Some(MarketSymbol {
+                base: "btc",
+                quote: "eur",
+                venue: Some("darkpool")
+            })
+        );
+    }
+
+    #[test]
+    fn malformed_online_pair_is_ignored() {
+        // GIVEN Kraken returns one valid pair and malformed online pairs
+        let response = AssetPairsResponse {
+            error: vec![],
+            result: HashMap::from([
+                (
+                    "valid".to_string(),
+                    Pair {
+                        wsname: "BTC/EUR".to_string(),
+                        status: "online".to_string(),
+                    },
+                ),
+                (
+                    "broken".to_string(),
+                    Pair {
+                        wsname: "BROKEN".to_string(),
+                        status: "online".to_string(),
+                    },
+                ),
+                (
+                    "empty-venue".to_string(),
+                    Pair {
+                        wsname: "ETH/EUR:".to_string(),
+                        status: "online".to_string(),
+                    },
+                ),
+                (
+                    "multiple-venues".to_string(),
+                    Pair {
+                        wsname: "ETH/EUR:SPOT:EXTRA".to_string(),
+                        status: "online".to_string(),
+                    },
+                ),
+            ]),
+        };
+
+        // WHEN the online pairs are parsed
+        let symbols = parse_online_market_symbols(&response).unwrap();
+
+        // THEN the malformed pair is ignored and the valid pair is retained
+        assert_eq!(symbols, ["btc/eur"]);
+    }
+
+    #[test]
+    fn snapshot_without_usable_online_pairs_is_rejected() {
+        // GIVEN Kraken returns only offline or malformed pairs
+        let response = AssetPairsResponse {
+            error: vec![],
+            result: HashMap::from([
+                (
+                    "offline".to_string(),
+                    Pair {
+                        wsname: "BTC/EUR".to_string(),
+                        status: "offline".to_string(),
+                    },
+                ),
+                (
+                    "broken".to_string(),
+                    Pair {
+                        wsname: "BROKEN".to_string(),
+                        status: "online".to_string(),
+                    },
+                ),
+            ]),
+        };
+
+        // WHEN the online snapshot is parsed
+        let result = parse_online_market_symbols(&response);
+
+        // THEN the empty snapshot is rejected so it cannot delete every market
+        assert!(result.is_err());
+    }
 }

--- a/dcapal-backend/crates/backend/src/ports/outbound/repository/market_data/mod.rs
+++ b/dcapal-backend/crates/backend/src/ports/outbound/repository/market_data/mod.rs
@@ -1,6 +1,8 @@
 mod redis_asset;
 mod redis_market;
 
+use std::collections::HashSet;
+
 use self::{redis_asset::RedisAsset, redis_market::RedisMarket};
 use crate::{
     app::domain::entity::{Asset, AssetId, AssetKind, Market, MarketId},
@@ -57,6 +59,19 @@ impl MarketDataRepository {
         } else {
             Err(DcaError::RepositoryStoreFailure(market.id.clone()))
         }
+    }
+
+    /// Deletes market fields that are absent from a complete Kraken snapshot.
+    ///
+    /// Redis is inspected directly because the service market cache is lazy and
+    /// does not necessarily contain every stored market.
+    pub async fn delete_markets_not_in(
+        &self,
+        market_ids: &HashSet<MarketId>,
+    ) -> Result<Vec<MarketId>> {
+        let mut redis = self.redis.get().await?;
+
+        Market::delete_not_in(market_ids, &mut redis).await
     }
 
     pub async fn update_mkt_price(&self, market: &Market) -> Result<()> {

--- a/dcapal-backend/crates/backend/src/ports/outbound/repository/market_data/redis_market.rs
+++ b/dcapal-backend/crates/backend/src/ports/outbound/repository/market_data/redis_market.rs
@@ -1,5 +1,7 @@
 use async_trait::async_trait;
 use futures::{StreamExt, TryStreamExt};
+use std::collections::HashSet;
+
 use tracing::{debug, error};
 
 use super::MarketDataRepository;
@@ -10,10 +12,35 @@ use crate::{
 };
 
 const MARKET_KEY: &str = concatcp!(REDIS_BASE, ':', "market");
+const DELETE_STALE_MARKETS_SCRIPT: &str = r#"
+local existing = redis.call('HKEYS', KEYS[1])
+local keep = {}
+for _, id in ipairs(ARGV) do
+    keep[id] = true
+end
+
+local stale = {}
+for _, id in ipairs(existing) do
+    if not keep[id] then
+        table.insert(stale, id)
+    end
+end
+
+if #stale > 0 then
+    redis.call('HDEL', KEYS[1], unpack(stale))
+end
+
+return stale
+"#;
 
 #[async_trait]
 pub trait RedisMarket {
     async fn store(&self, conn: &mut impl redis::AsyncCommands) -> Result<bool>;
+
+    async fn delete_not_in(
+        market_ids: &HashSet<MarketId>,
+        conn: &mut impl redis::AsyncCommands,
+    ) -> Result<Vec<MarketId>>;
 
     async fn find_by_id(
         id: &MarketId,
@@ -42,6 +69,36 @@ impl RedisMarket for Market {
 
         debug!("Successfully stored '{} {}': {}", MARKET_KEY, self.id, json);
         Ok(true)
+    }
+
+    async fn delete_not_in(
+        market_ids: &HashSet<MarketId>,
+        conn: &mut impl redis::AsyncCommands,
+    ) -> Result<Vec<MarketId>> {
+        if market_ids.is_empty() {
+            return Err(DcaError::Generic(
+                "Cannot reconcile markets from an empty Kraken snapshot".to_string(),
+            ));
+        }
+
+        let mut cmd = redis::cmd("EVAL");
+        cmd.arg(DELETE_STALE_MARKETS_SCRIPT).arg(1).arg(MARKET_KEY);
+        for market_id in market_ids {
+            cmd.arg(market_id);
+        }
+
+        let deleted: Vec<MarketId> = cmd.query_async(conn).await?;
+
+        if deleted.is_empty() {
+            return Ok(deleted);
+        }
+
+        debug!(
+            "Removed {} stale Kraken markets from '{}'",
+            deleted.len(),
+            MARKET_KEY
+        );
+        Ok(deleted)
     }
 
     async fn find_by_id(
@@ -164,5 +221,91 @@ async fn resolve_market(market: MarketDto, repo: &MarketDataRepository) -> Resul
             Ok(None)
         }
         (Some(b), Some(q)) => Ok(Some(Market::new(market.id, b, q, market.price))),
+    }
+}
+
+#[cfg(test)]
+fn stale_market_ids(existing: &[MarketId], keep: &HashSet<MarketId>) -> HashSet<MarketId> {
+    existing
+        .iter()
+        .filter(|id| !keep.contains(*id))
+        .cloned()
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::stale_market_ids;
+
+    #[test]
+    fn reconciliation_deletes_only_fields_outside_the_snapshot() {
+        // GIVEN the market hash contains Kraken markets in an arbitrary order
+        let existing = [
+            "etheur".to_string(),
+            "btcusd".to_string(),
+            "legacy".to_string(),
+            "adaeur".to_string(),
+        ];
+        let desired = [
+            "adaeur".to_string(),
+            "btcusd".to_string(),
+            "etheur".to_string(),
+        ]
+        .into_iter()
+        .collect::<HashSet<_>>();
+
+        // WHEN stale fields are selected for HDEL
+        let stale = stale_market_ids(&existing, &desired);
+
+        // THEN only the field absent from the complete snapshot is deleted
+        assert_eq!(stale, ["legacy".to_string()].into_iter().collect());
+    }
+
+    #[test]
+    fn reconciliation_selection_is_independent_of_redis_key_order() {
+        // GIVEN the Redis HKEYS result order changes between calls
+        let desired = ["btcusd".to_string()].into_iter().collect::<HashSet<_>>();
+
+        // WHEN stale fields are selected from both orderings
+        let first = stale_market_ids(
+            &[
+                "zeta".to_string(),
+                "alpha".to_string(),
+                "btcusd".to_string(),
+            ],
+            &desired,
+        );
+        let second = stale_market_ids(
+            &[
+                "alpha".to_string(),
+                "btcusd".to_string(),
+                "zeta".to_string(),
+            ],
+            &desired,
+        );
+
+        // THEN the same stale fields are selected for the single atomic HDEL
+        assert_eq!(
+            first,
+            ["alpha".to_string(), "zeta".to_string()]
+                .into_iter()
+                .collect()
+        );
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn reconciliation_selection_returns_no_fields_when_all_markets_are_live() {
+        // GIVEN every Redis market field exists in the current Kraken snapshot
+        let existing = ["btcusd".to_string(), "etheur".to_string()];
+        let desired = existing.iter().cloned().collect::<HashSet<_>>();
+
+        // WHEN stale fields are selected for HDEL
+        let stale = stale_market_ids(&existing, &desired);
+
+        // THEN no field is selected for deletion
+        assert!(stale.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
Reconcile Redis market data with Kraken’s live market snapshot every hour and invalidate affected caches. This prevents stale or deleted markets from remaining available to consumers.

## Related Issues
None

## Changes Made
- Added hourly Kraken market reconciliation with safe handling for empty or malformed snapshots.
- Removed stale Redis market fields using an atomic Lua script.
- Invalidated deleted markets and dependent conversion-rate caches.
- Added generation checks to prevent stale concurrent market lookups from repopulating caches.
- Preserved daily discovery behavior and updated its freshness tracking.

## Motivation
Kraken markets can be removed after the initial discovery run, leaving stale markets and conversion rates cached indefinitely. Periodic reconciliation keeps persisted and in-memory market data aligned with Kraken.

## Design decisions
- Reject empty snapshots before deleting data to avoid wiping all markets after an invalid provider response.
- Keep reconciliation separate from daily asset discovery so stale markets are removed hourly without increasing the frequency of broader discovery.
- Use a cache generation counter to prevent in-flight lookups from restoring entries invalidated during reconciliation.

## Validation
- **Market snapshot filtering:** `GIVEN` online, offline, normalized, and malformed Kraken pairs, `WHEN` the snapshot is parsed, `THEN` only valid online market IDs are retained.
- **Safe empty snapshot handling:** `GIVEN` no usable online pairs, `WHEN` reconciliation prepares the snapshot, `THEN` the operation is rejected without deleting all markets.
- **Cache invalidation:** `GIVEN` a cached market and dependent conversion rate, `WHEN` the market is invalidated, `THEN` both are removed from the caches.
- **Daily discovery timing:** `GIVEN` a missing, same-day, or previous-day marker, `WHEN` freshness is checked, `THEN` discovery runs only when due.

## Testing
Not run (not requested).